### PR TITLE
Data Format flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 cmd/ldp-testdata/ldp-testdata
 extract-output
 

--- a/testdata/make-all.go
+++ b/testdata/make-all.go
@@ -1,0 +1,70 @@
+package testdata
+
+import "path/filepath"
+
+type DataFmt int
+
+const (
+	FolioJSON DataFmt = iota
+	JSONArray
+)
+
+type OutputParams struct {
+	OutputDir  string
+	DataFormat DataFmt
+	Indent     bool
+}
+type AllParams struct {
+	Output       OutputParams
+	NumGroups    int
+	NumUsers     int
+	NumLocations int
+	NumLoans     int
+}
+
+func MakeAll(p AllParams) {
+	GenerateGroups(p.Output, p.NumGroups)
+	GenerateUsers(p.Output, p.NumUsers)
+	GenerateLocations(p.Output, p.NumLocations)
+	GenerateItems(p.Output)
+	GenerateLoans(p.Output, p.NumLoans)
+	GenerateCirculationLoans(p.Output)
+	GenerateStorageItems(p.Output)
+}
+
+func writeOutput(params OutputParams, filename, jsonKeyname string, slice []interface{}) {
+	filepath := filepath.Join(params.OutputDir, filename)
+	if params.DataFormat == JSONArray {
+		writeSliceToFile(filepath, slice, params.Indent)
+	} else {
+		writeFolioSliceToFile(jsonKeyname, filepath, slice, params.Indent)
+	}
+}
+
+func streamRandomItem(params OutputParams, filename, jsonKeyname string) chan interface{} {
+	chnl := make(chan interface{}, 1)
+	filepath := filepath.Join(params.OutputDir, filename)
+	if params.DataFormat == JSONArray {
+		go streamRandomSliceItem(filepath, chnl)
+	} else {
+		go streamRandomFolioSliceItem(jsonKeyname, filepath, chnl)
+	}
+	return chnl
+}
+func streamOutputLinearly(params OutputParams, filename, jsonKeyname string) chan interface{} {
+	chnl := make(chan interface{}, 1)
+	filepath := filepath.Join(params.OutputDir, filename)
+	if params.DataFormat == JSONArray {
+		go streamSliceItem(filepath, chnl)
+	} else {
+		go streamFolioSliceItem(jsonKeyname, filepath, chnl)
+	}
+	return chnl
+}
+
+func ParseDataFmtFlag(flag string) DataFmt {
+	if flag == "folioJSON" {
+		return FolioJSON
+	}
+	return JSONArray // otherwise
+}

--- a/testdata/make-circulation-loans.go
+++ b/testdata/make-circulation-loans.go
@@ -1,7 +1,6 @@
 package testdata
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"path/filepath"
@@ -58,15 +57,13 @@ func makeItemsMap(filepath string) map[string]item {
 	return itemsMap
 }
 
-func GenerateCirculationLoans(outputDir string) {
+func GenerateCirculationLoans(outputParams OutputParams) {
 	var circLoans []interface{}
-	itemsPath := filepath.Join(outputDir, "items.json")
+	itemsPath := filepath.Join(outputParams.OutputDir, "items.json")
 	itemsMap := makeItemsMap(itemsPath)
-	numFiles := countLoanStorageFiles(outputDir)
+	numFiles := countLoanStorageFiles(outputParams.OutputDir)
 	for i := 1; i <= numFiles; i++ {
-		loanStorageFilepath := filepath.Join(outputDir, "loans.json."+strconv.Itoa(i))
-		loanChnl := make(chan interface{}, 1)
-		go streamSliceItem(loanStorageFilepath, loanChnl)
+		loanChnl := streamOutputLinearly(outputParams, "loans.json."+strconv.Itoa(i), "loans")
 		for oneLoan := range loanChnl {
 			var loanObj circulationLoan
 			mapstructure.Decode(oneLoan, &loanObj)
@@ -83,8 +80,6 @@ func GenerateCirculationLoans(outputDir string) {
 			}
 			circLoans = append(circLoans, loanObj)
 		}
-		filepath := filepath.Join(outputDir, "circloan.json."+strconv.Itoa(i))
-		fmt.Println("Writing", filepath)
-		writeSliceToFile(filepath, circLoans, true)
+		writeOutput(outputParams, "circloan.json."+strconv.Itoa(i), "loans", circLoans)
 	}
 }

--- a/testdata/make-groups.go
+++ b/testdata/make-groups.go
@@ -1,7 +1,6 @@
 package testdata
 
 import (
-	"path/filepath"
 	"strconv"
 
 	uuid "github.com/satori/go.uuid"
@@ -20,7 +19,7 @@ type group struct {
 	Metadata groupMetadata `json:"metadata"`
 }
 
-func GenerateGroups(outputDir string, numGroups int) {
+func GenerateGroups(outputParams OutputParams, numGroups int) {
 	groupNames := []string{
 		"Freshman", "Sophomore", "Junior", "Senior", "Graduate", "Alumni", "Faculty",
 		"Staff", "Affiliate_A", "Affiliate_B", "Affiliate_C", "Affiliate_D",
@@ -44,7 +43,7 @@ func GenerateGroups(outputDir string, numGroups int) {
 		groupNames = groupNames[:numGroups]
 		groupDesc = groupDesc[:numGroups]
 	}
-	makeGroup := func(i int) group {
+	newGroup := func(i int) group {
 		creator := uuid.Must(uuid.NewV4()).String()
 		return group{
 			Group: groupNames[i],
@@ -60,9 +59,8 @@ func GenerateGroups(outputDir string, numGroups int) {
 
 	var groups []interface{}
 	for i := 0; i < len(groupNames); i++ {
-		g := makeGroup(i)
+		g := newGroup(i)
 		groups = append(groups, g)
 	}
-	filepath := filepath.Join(outputDir, "groups.json")
-	writeSliceToFile(filepath, groups, true)
+	writeOutput(outputParams, "groups.json", "usergroups", groups)
 }

--- a/testdata/make-locations.go
+++ b/testdata/make-locations.go
@@ -1,8 +1,6 @@
 package testdata
 
 import (
-	"path/filepath"
-
 	"github.com/icrowley/fake"
 	uuid "github.com/satori/go.uuid"
 )
@@ -12,7 +10,7 @@ type location struct {
 	ID   string `json:"id"`
 }
 
-func GenerateLocations(outputDir string, numLocations int) {
+func GenerateLocations(outputParams OutputParams, numLocations int) {
 	makeLocation := func() location {
 		return location{
 			Name: fake.LastName() + " Library",
@@ -24,6 +22,5 @@ func GenerateLocations(outputDir string, numLocations int) {
 		l := makeLocation()
 		locations = append(locations, l)
 	}
-	filepath := filepath.Join(outputDir, "locations.json")
-	writeSliceToFile(filepath, locations, true)
+	writeOutput(outputParams, "locations.json", "locations", locations)
 }

--- a/testdata/make-storage-items.go
+++ b/testdata/make-storage-items.go
@@ -3,7 +3,6 @@ package testdata
 import (
 	"fmt"
 	"math/rand"
-	"path/filepath"
 	"strconv"
 	"time"
 
@@ -31,14 +30,12 @@ func randomCopyNumbers() []string {
 	return []string{strconv.Itoa(random(1, 5))}
 }
 
-// StorageItems share the same information with inventory items
+// GenerateStorageItems creates items that share the same information with inventory items
 // (ID, holdingsRecordId, barcode)
-func GenerateStorageItems(outputDir string) {
+func GenerateStorageItems(outputParams OutputParams) {
 	rand.Seed(time.Now().UnixNano())
 	var storageItems []interface{}
-	itemsPath := filepath.Join(outputDir, "items.json")
-	itemsChnl := make(chan interface{}, 1)
-	go streamSliceItem(itemsPath, itemsChnl)
+	itemsChnl := streamOutputLinearly(outputParams, "items.json", "items")
 	for oneItem := range itemsChnl {
 		var itemObj item
 		mapstructure.Decode(oneItem, &itemObj)
@@ -52,6 +49,5 @@ func GenerateStorageItems(outputDir string) {
 		}
 		storageItems = append(storageItems, oneStorageItem)
 	}
-	filepath := filepath.Join(outputDir, "storageItems.json")
-	writeFolioSliceToFile("items", filepath, storageItems, true)
+	writeOutput(outputParams, "storageItems.json", "items", storageItems)
 }

--- a/testdata/make-users.go
+++ b/testdata/make-users.go
@@ -2,7 +2,6 @@ package testdata
 
 import (
 	"math/rand"
-	"path/filepath"
 	"time"
 
 	"github.com/icrowley/fake"
@@ -24,15 +23,12 @@ func isActive() bool {
 	randNum := rand.Intn(2)
 	if randNum == 0 {
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
-func GenerateUsers(outputDir string, numUsers int) {
-	chnl := make(chan interface{}, 1)
-	groupsPath := filepath.Join(outputDir, "groups.json")
-	go streamRandomSliceItem(groupsPath, chnl)
+func GenerateUsers(outputParams OutputParams, numUsers int) {
+	chnl := streamRandomItem(outputParams, "groups.json", "usergroups")
 	makeUser := func() user {
 		randomGroup, _ := <-chnl
 		randomGroupMap := randomGroup.(map[string]interface{})
@@ -53,6 +49,5 @@ func GenerateUsers(outputDir string, numUsers int) {
 		u := makeUser()
 		users = append(users, u)
 	}
-	filepath := filepath.Join(outputDir, "users.json")
-	writeSliceToFile(filepath, users, true)
+	writeOutput(outputParams, "users.json", "users", users)
 }

--- a/testdata/randomline.go
+++ b/testdata/randomline.go
@@ -105,7 +105,7 @@ func streamRandomLine(filename string, chnl chan string) {
 	// close(chnl)
 }
 
-// Parse the file as valid JSON
+// Parse the file as a JSON array, e.g. [{},{},...]
 func streamRandomSliceItem(filename string, chnl chan interface{}) {
 	jsonFile, _ := os.Open(filename)
 	byteValue, _ := ioutil.ReadAll(jsonFile)
@@ -119,7 +119,22 @@ func streamRandomSliceItem(filename string, chnl chan interface{}) {
 	}
 }
 
-// Linearly parse the file as valid JSON
+// Parse the file as FOLIO JSON, e.g. {keyname:[{},{},...]}
+func streamRandomFolioSliceItem(jsonKeyname, filename string, chnl chan interface{}) {
+	jsonFile, _ := os.Open(filename)
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+	var result map[string]interface{}
+	json.Unmarshal(byteValue, &result)
+	jsonArray, _ := result[jsonKeyname].([]interface{})
+	for {
+		rand.Seed(time.Now().UnixNano())
+		randomNum := rand.Intn(len(jsonArray))
+		randomItem := jsonArray[randomNum]
+		chnl <- randomItem
+	}
+}
+
+// Linearly parse the file as a JSON array
 func streamSliceItem(filename string, chnl chan interface{}) {
 	jsonFile, _ := os.Open(filename)
 	byteValue, _ := ioutil.ReadAll(jsonFile)
@@ -127,6 +142,19 @@ func streamSliceItem(filename string, chnl chan interface{}) {
 	json.Unmarshal(byteValue, &result)
 	for i := 0; i < len(result); i++ {
 		chnl <- result[i]
+	}
+	close(chnl)
+}
+
+// Linearly parse the file as FOLIO JSON
+func streamFolioSliceItem(jsonKeyname, filename string, chnl chan interface{}) {
+	jsonFile, _ := os.Open(filename)
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+	var result map[string]interface{}
+	json.Unmarshal(byteValue, &result)
+	jsonArray, _ := result[jsonKeyname].([]interface{})
+	for i := 0; i < len(jsonArray); i++ {
+		chnl <- jsonArray[i]
 	}
 	close(chnl)
 }

--- a/testdata/randomvalues.go
+++ b/testdata/randomvalues.go
@@ -7,18 +7,18 @@ import (
 	"time"
 )
 
-// generate sample data that are random, based on either a list of values or a range/step
+// generate random values based on either a list of values or a range/step
 //   - A list of values would be like the values in groups.groupname:
 //       [faculty, staff, undergraduate student, graduate student]
 //   - A range/step would something like a for-loop: range from 10-100, step 5 = 10, 15, 20, etc.
 
 // outputSize corresponds to the number of rows in the table that you want to generate
 
-// generateRandom doesn't know anything about the data.
+// makeRandomValues doesn't know anything about the data.
 // It just wants to know how much data to generate and how many possible values there are.
 
 // Streams integers, each integer being between 0 and the given max
-func GenerateRandomValues(maxValue, outputSize int, chnl chan int) {
+func makeRandomValues(maxValue, outputSize int, chnl chan int) {
 	rand.Seed(time.Now().UnixNano())
 	for i := 0; i < outputSize; i++ {
 		chnl <- rand.Intn(maxValue)
@@ -26,7 +26,7 @@ func GenerateRandomValues(maxValue, outputSize int, chnl chan int) {
 	close(chnl)
 }
 
-type Generator struct {
+type ValueParams struct {
 	MaxValue   int
 	OutputSize int
 	Channel    chan int
@@ -36,33 +36,33 @@ type ChannelResponse struct {
 	Ok    bool
 }
 
-// Creates 3 example generators, streams responses from each
-func threeGenerators() {
-	firstGen := Generator{2, 10, make(chan int)}
-	secondGen := Generator{4, 10, make(chan int)}
-	thirdGen := Generator{6, 10, make(chan int)}
-	generators := []Generator{firstGen, secondGen, thirdGen}
-	for _, gen := range generators {
-		go GenerateRandomValues(gen.MaxValue, gen.OutputSize, gen.Channel)
+// Example of streaming 3 random values and outputting a string with them
+func threeInstances() {
+	valueType1 := ValueParams{2, 10, make(chan int)}
+	valueType2 := ValueParams{4, 10, make(chan int)}
+	valueType3 := ValueParams{6, 10, make(chan int)}
+	allValueTypes := []ValueParams{valueType1, valueType2, valueType3}
+	for _, valueType := range allValueTypes {
+		go makeRandomValues(valueType.MaxValue, valueType.OutputSize, valueType.Channel)
 	}
 	for {
-		// Get a response from each generator
+		// 1) Get a response from each generator
 		var responses []ChannelResponse
-		for _, gen := range generators {
+		for _, valueType := range allValueTypes {
 			resp := ChannelResponse{}
-			newVal, ok := <-gen.Channel
+			newVal, ok := <-valueType.Channel
 			resp.Value = newVal
 			resp.Ok = ok
 			// In this example, the streamed response is added to an array
 			// In actual usage, we'd want to use the response (e.g. forming a JSON record)
 			responses = append(responses, resp)
 		}
-		// Form a string from the responses
-		var genValues []int
+		// 2) Form a string from the responses
+		var values []int
 		var channelClosed = false
 		for _, resp := range responses {
 			if resp.Ok {
-				genValues = append(genValues, resp.Value)
+				values = append(values, resp.Value)
 			} else {
 				channelClosed = true
 				break
@@ -72,7 +72,7 @@ func threeGenerators() {
 			break
 		} else {
 			delim := " "
-			stringArray := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(genValues)), delim), "[]")
+			stringArray := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(values)), delim), "[]")
 			fmt.Println("Received", stringArray)
 		}
 	}


### PR DESCRIPTION
Two formats of output:
- The JSON that the FOLIO API returns (default), e.g. `{users:[...], totalCount: 120}`, which requires knowledge of the key name "users"
- Just a JSON array, e.g. `[...]`, which omits the key name.

The purpose of this repo is to simulate FOLIO API data, so the `folioJSON` format is the default. But the `jsonArray` format may be preferable for some. Another format, one JSON object per line, could be added in the future if desired.