### PR TITLE
LDP-31: Generate manifest file

### DIFF
--- a/testdata/make-groups.go
+++ b/testdata/make-groups.go
@@ -62,5 +62,16 @@ func GenerateGroups(outputParams OutputParams, numGroups int) {
 		g := newGroup(i)
 		groups = append(groups, g)
 	}
-	writeOutput(outputParams, "groups.json", "usergroups", groups)
+	filename := "groups.json"
+	objKey := "usergroups"
+	writeOutput(outputParams, filename, objKey, groups)
+
+	updateManifest(fileDef{
+		Module:    "mod-users",
+		Path:      "/groups",
+		Filename:  filename,
+		ObjectKey: objKey,
+		NumFiles:  1,
+		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html",
+	}, outputParams)
 }

--- a/testdata/make-locations.go
+++ b/testdata/make-locations.go
@@ -22,5 +22,17 @@ func GenerateLocations(outputParams OutputParams, numLocations int) {
 		l := makeLocation()
 		locations = append(locations, l)
 	}
-	writeOutput(outputParams, "locations.json", "locations", locations)
+
+	filename := "locations.json"
+	objKey := "locations"
+	writeOutput(outputParams, filename, objKey, locations)
+
+	updateManifest(fileDef{
+		Module:    "mod-inventory-storage",
+		Path:      "/locations",
+		Filename:  filename,
+		ObjectKey: objKey,
+		NumFiles:  1,
+		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html",
+	}, outputParams)
 }

--- a/testdata/make-manifest.go
+++ b/testdata/make-manifest.go
@@ -1,0 +1,60 @@
+package testdata
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type fileDef struct {
+	Module    string `json:"module"`    // the module
+	Path      string `json:"path"`      // API route simulated
+	Filename  string `json:"filename"`  // the output filename
+	ObjectKey string `json:"objectKey"` // the field that contains the array in the output JSON
+	NumFiles  int    `json:"numFiles"`  // the number of files a part of this output
+	Doc       string `json:"doc"`       // URL to the API documentation
+}
+
+func toInterface(originals []fileDef) []interface{} {
+	newThings := make([]interface{}, len(originals))
+	for i, s := range originals {
+		newThings[i] = s
+	}
+	return newThings
+}
+
+func updateManifest(def fileDef, params OutputParams) {
+	filepath := filepath.Join(params.OutputDir, "manifest.json")
+
+	jsonFile, errOpeningFile := os.Open(filepath)
+	if errOpeningFile != nil {
+		// write file
+		var fileDefs []interface{}
+		fileDefs = append(fileDefs, def)
+		writeSliceToFile(filepath, fileDefs, true)
+	} else {
+		// read JSON, then update it
+
+		byteValue, err := ioutil.ReadAll(jsonFile)
+		if err != nil {
+			panic(err)
+		}
+		var defs []fileDef
+		json.Unmarshal(byteValue, &defs)
+		foundTarget := false
+		for i := 0; i < len(defs); i++ {
+			if defs[i].Filename == def.Filename {
+				logger.Debugf("Overwriting entry for %s", def.Filename)
+				defs[i] = def
+				foundTarget = true
+				break
+			}
+		}
+		if !foundTarget {
+			defs = append(defs, def)
+		}
+		newDefs := toInterface(defs)
+		writeSliceToFile(filepath, newDefs, true)
+	}
+}

--- a/testdata/make-storage-items.go
+++ b/testdata/make-storage-items.go
@@ -52,5 +52,16 @@ func GenerateStorageItems(outputParams OutputParams, numItems int) {
 		oneStorageItem := makeStorageItem()
 		storageItems = append(storageItems, oneStorageItem)
 	}
-	writeOutput(outputParams, "storageItems.json", "items", storageItems)
+	filename := "storageItems.json"
+	objKey := "items"
+	writeOutput(outputParams, filename, objKey, storageItems)
+
+	updateManifest(fileDef{
+		Module:    "mod-inventory-storage",
+		Path:      "/item-storage/items",
+		Filename:  filename,
+		ObjectKey: objKey,
+		NumFiles:  1,
+		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html",
+	}, outputParams)
 }

--- a/testdata/make-users.go
+++ b/testdata/make-users.go
@@ -49,5 +49,16 @@ func GenerateUsers(outputParams OutputParams, numUsers int) {
 		u := makeUser()
 		users = append(users, u)
 	}
-	writeOutput(outputParams, "users.json", "users", users)
+	filename := "users.json"
+	objKey := "users"
+	writeOutput(outputParams, filename, objKey, users)
+
+	updateManifest(fileDef{
+		Module:    "mod-users",
+		Path:      "/users",
+		Filename:  filename,
+		ObjectKey: objKey,
+		NumFiles:  1,
+		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-users/users.html",
+	}, outputParams)
 }


### PR DESCRIPTION
https://issues.folio.org/browse/LDP-31

Output manifest.json which is an array of file definitions:

```

type fileDef struct {
	Module    string // the module
	Path      string // API route simulated
	Filename  string // the output filename
	ObjectKey string // the field that contains the array in the output JSON
	NumFiles  int    // the number of files a part of this output
	Doc       string // URL to the API documentation
}
```

Example file:

```
→ cat extract-output/20190403_144123/manifest.json
[
    {
        "module": "mod-users",
        "path": "/groups",
        "filename": "groups.json",
        "objectKey": "usergroups",
        "numFiles": 1,
        "doc": "https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html"
    },
    {
        "module": "mod-users",
        "path": "/users",
        "filename": "users.json",
        "objectKey": "users",
        "numFiles": 1,
        "doc": "https://s3.amazonaws.com/foliodocs/api/mod-users/users.html"
    },
    {
        "module": "mod-inventory-storage",
        "path": "/locations",
        "filename": "locations.json",
        "objectKey": "locations",
        "numFiles": 1,
        "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html"
    },
    {
        "module": "mod-inventory-storage",
        "path": "/item-storage/items",
        "filename": "storageItems.json",
        "objectKey": "items",
        "numFiles": 1,
        "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html"
    },
    {
        "module": "mod-circulation-storage",
        "path": "/loan-storage/loans",
        "filename": "loans.json",
        "objectKey": "loans",
        "numFiles": 11,
        "doc": "https://s3.amazonaws.com/foliodocs/api/mod-circulation-storage/loan-storage.html"
    }
]
```

The files should be loaded in the same order as the array.