### PR TITLE
Refactor to use filedefs.json as config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,55 +18,42 @@ Overview
 
 This purpose of this repo is to generate large amounts of fake FOLIO data to support the LDP analytics team.
 
-To download and compile:
+To download:
 
 ```shell
 go get github.com/folio-org/ldp-testdata
-cd ldp-testdata/cmd/ldp-testdata
-go build
-cd ../..
 ```
 
 To run:
 ```shell
-cmd/ldp-testdata/ldp-testdata all
+go run ./cmd/ldp-testdata/main.go
 ```
 
 Usage
 --------
 ```
-cmd/ldp-testdata/ldp-testdata
-Usage:
-./ldp-testdata FLAGS [all|groups|users|locations|loans|storageitems]
-  where FLAGS include:
+go run ./cmd/ldp-testdata/main.go [FLAGS]
+
+All flags are optional
+
   -dataFormat string
     	The outputted data format [folioJSON|jsonArray] (default "folioJSON")
   -dir string
-    	The directory to use for extract output. If the selected test data depends on
-    	other test data (e.g. 'users' depends on 'groups'), that dependency should exist
-    	in this directory.
-  -nGroups int
-    	The number of groups to create (default 12)
-  -nItems int
-    	The number of items to create (default 10000)
-  -nLoans int
-    	The number of loans to create (default 10000)
-  -nLocations int
-    	The number of locations to create (default 20)
-  -nUsers int
-    	The number of users to create (default 30000)
+    	The directory to store output
+  -fileDefs string
+    	The filepath of the JSON file definitions (default "filedefs.json")
+  -json string
+    	JSON array to override the number of objects set filedefs.json
+    	Example: '[{"path": "/loan-storage/loans", "n":50000}]'
+  -only-json
+    	Use with the -json flag to ignore filedefs.json
 ```
 
-Typically, you will want to run `ldp-testdata all` to generate all data. You can tweak the parameters
-using the options, e.g.
+Edit filedefs.json to change the number of objects created for each path, or 
+use the `-json` flag to override the number of objects set filedefs.json
 
 ```shell
-ldp-testdata -nUsers=50000 -nGroups=20 -nLoans=800000 -dir=./myOutput all
-```
-
-You can specify the same directory as a previous run to overwrite one type of data:
-```shell
-ldp-testdata -dir=./myOutput nUsers=20000 users
+go run ./cmd/ldp-testdata/main.go -json='[{"path": "/loan-storage/loans", "n":50000}]'
 ```
 
 **This software is under active development. Use this software only for testing purposes.**

--- a/cmd/ldp-testdata/main.go
+++ b/cmd/ldp-testdata/main.go
@@ -2,108 +2,44 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"os"
-	"path/filepath"
-	"time"
 
 	"github.com/folio-org/ldp-testdata/logging"
 	"github.com/folio-org/ldp-testdata/testdata"
-	"github.com/folio-org/ldp-testdata/web"
 )
 
 var logger = logging.Logger
 
-func makeTimestampedDir(dirFlag string) string {
-	if dirFlag != "" {
-		os.MkdirAll(dirFlag, os.ModePerm) // Make the directory if it does not already exist
-		return dirFlag
-	}
-	extractDir := "./extract-output"
-	currentTime := time.Now()
-	timeStr := currentTime.Format("20060102_150405")
-	outputDir := filepath.Join(extractDir, timeStr)
-	os.MkdirAll(outputDir, os.ModePerm)
-	return outputDir
-}
-
-func printUsage() {
-	fmt.Println("Usage:")
-	fmt.Println("./ldp-testdata FLAGS [all|groups|users|locations|loans|storageitems]")
-	fmt.Println("  where FLAGS include:")
-	flag.PrintDefaults() // Print the flag help strings
-}
-
 func main() {
 	logging.Init()
 	flag.Usage = func() {
-		printUsage()
+		testdata.PrintUsage()
 	}
-	openBrowser := flag.Bool("openBrowser", true, "Whether to open a web browser to the UI")
-	dirFlag := flag.String("dir", "",
-		`The directory to use for extract output. If the selected test data depends on
-other test data (e.g. 'users' depends on 'groups'), that dependency should exist
-in this directory.`)
-	fileDefsFlag := flag.String("fileDefs", "", "The filepath of the JSON file definitions")
+	// openBrowser := flag.Bool("openBrowser", true, "Whether to open a web browser to the UI")
+	dirFlag := flag.String("dir", "", "The directory to store output")
+	fileDefsFlag := flag.String("fileDefs", "filedefs.json", "The filepath of the JSON file definitions")
 	dataFmtFlag := flag.String("dataFormat", "folioJSON", `The outputted data format [folioJSON|jsonArray]`)
-	numGroupsFlag := flag.Int("nGroups", 12, `The number of groups to create`)
-	numUsersFlag := flag.Int("nUsers", 30000, `The number of users to create`)
-	numLocationsFlag := flag.Int("nLocations", 20, `The number of locations to create`)
-	numItemsFlag := flag.Int("nItems", 10000, `The number of items to create`)
-	numLoansFlag := flag.Int("nLoans", 10000, `The number of loans to create`)
+	fileDefsOverrideFlag := flag.String("json", "", `JSON array to override the number of objects set filedefs.json
+Example: '[{"path": "/loan-storage/loans", "n":50000}]'`)
+	onlyUseOverrideFlag := flag.Bool("only-json", false, "Use with the -json flag to ignore filedefs.json")
 	flag.Parse()
 
-	// VALIDATE ARGUMENT 'MODE' IS VALID
-	modes := map[string]bool{
-		"all":          true,
-		"groups":       true,
-		"users":        true,
-		"locations":    true,
-		"loans":        true,
-		"storageitems": true,
-	}
-	fileDefs := testdata.ParseFileDefs(*fileDefsFlag)
-	web.Run(*openBrowser, fileDefs)
+	fileDefs := testdata.ParseFileDefs(*fileDefsFlag,
+		*fileDefsOverrideFlag,
+		*onlyUseOverrideFlag)
+	funcs := testdata.MapFileDefsToFunc(fileDefs)
 
-	if len(flag.Args()) < 1 {
-		printUsage()
-		os.Exit(1)
-	}
-	mode := flag.Arg(0)
-	if _, ok := modes[mode]; !ok {
-		fmt.Printf("Error: '%s' is not a valid argument\n", mode)
-		printUsage()
-		os.Exit(1)
-	}
+	// web.Run(*openBrowser, fileDefs)
+
 	// If we need to do any more validation of params, change this to a NewParams() function
 	// which does the validation
 	p := testdata.AllParams{
 		FileDefs: fileDefs,
 		Output: testdata.OutputParams{
-			OutputDir:  makeTimestampedDir(*dirFlag),
+			OutputDir:  testdata.MakeTimestampedDir(*dirFlag),
 			DataFormat: testdata.ParseDataFmtFlag(*dataFmtFlag),
 			Indent:     true,
 		},
-		NumGroups:    *numGroupsFlag,
-		NumUsers:     *numUsersFlag,
-		NumLocations: *numLocationsFlag,
-		NumItems:     *numItemsFlag,
-		NumLoans:     *numLoansFlag,
 	}
-
-	switch mode {
-	case "all":
-		testdata.MakeAll(p)
-	case "groups":
-		testdata.GenerateGroups(p, p.NumGroups)
-	case "users":
-		testdata.GenerateUsers(p, p.NumUsers)
-	case "locations":
-		testdata.GenerateLocations(p, p.NumLocations)
-	case "storageitems":
-		testdata.GenerateStorageItems(p, p.NumItems)
-	case "loans":
-		testdata.GenerateLoans(p, p.NumLoans)
-	}
+	testdata.MakeAll(funcs, p)
 	logger.Infof("Generated data in %s\n", p.Output.OutputDir)
 }

--- a/cmd/ldp-testdata/main.go
+++ b/cmd/ldp-testdata/main.go
@@ -28,7 +28,7 @@ func makeTimestampedDir(dirFlag string) string {
 
 func printUsage() {
 	fmt.Println("Usage:")
-	fmt.Println("./ldp-testdata FLAGS [all|groups|users|locations|items|loans|circloans|storageitems]")
+	fmt.Println("./ldp-testdata FLAGS [all|groups|users|locations|loans|storageitems]")
 	fmt.Println("  where FLAGS include:")
 	flag.PrintDefaults() // Print the flag help strings
 }

--- a/filedefs.json
+++ b/filedefs.json
@@ -4,34 +4,39 @@
       "path": "/groups",
       "filename": "groups.json",
       "objectKey": "usergroups",
-      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html"
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html",
+      "n": 12
   },
   {
       "module": "mod-users",
       "path": "/users",
       "filename": "users.json",
       "objectKey": "users",
-      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-users/users.html"
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-users/users.html",
+      "n": 30000
   },
   {
       "module": "mod-inventory-storage",
       "path": "/locations",
       "filename": "locations.json",
       "objectKey": "locations",
-      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html"
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html",
+      "n": 20
   },
   {
       "module": "mod-inventory-storage",
       "path": "/item-storage/items",
       "filename": "storageItems.json",
       "objectKey": "items",
-      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html"
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html",
+      "n": 10000
   },
   {
       "module": "mod-circulation-storage",
       "path": "/loan-storage/loans",
       "filename": "loans.json",
       "objectKey": "loans",
-      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-circulation-storage/loan-storage.html"
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-circulation-storage/loan-storage.html",
+      "n": 10000
   }
 ]

--- a/filedefs.json
+++ b/filedefs.json
@@ -1,0 +1,37 @@
+[
+  {
+      "module": "mod-users",
+      "path": "/groups",
+      "filename": "groups.json",
+      "objectKey": "usergroups",
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html"
+  },
+  {
+      "module": "mod-users",
+      "path": "/users",
+      "filename": "users.json",
+      "objectKey": "users",
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-users/users.html"
+  },
+  {
+      "module": "mod-inventory-storage",
+      "path": "/locations",
+      "filename": "locations.json",
+      "objectKey": "locations",
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html"
+  },
+  {
+      "module": "mod-inventory-storage",
+      "path": "/item-storage/items",
+      "filename": "storageItems.json",
+      "objectKey": "items",
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html"
+  },
+  {
+      "module": "mod-circulation-storage",
+      "path": "/loan-storage/loans",
+      "filename": "loans.json",
+      "objectKey": "loans",
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-circulation-storage/loan-storage.html"
+  }
+]

--- a/goat.yml
+++ b/goat.yml
@@ -1,0 +1,17 @@
+init_tasks:
+ - command: "pkill -f go-build"
+ - command: "go run cmd/ldp-testdata/main.go -openBrowser=true -fileDefs=./filedefs.json all"
+   nowait: true
+
+watchers:
+ - extension: html
+   tasks:
+   - command: "pkill -f go-build"
+   - command: "go run cmd/ldp-testdata/main.go -openBrowser=false -fileDefs=./filedefs.json all"
+     nowait: false
+ - extension: go
+   tasks:
+   - command: "pkill -f go-build"
+   - command: "go run cmd/ldp-testdata/main.go -openBrowser=false -fileDefs=./filedefs.json all"
+     nowait: true
+

--- a/testdata/make-all.go
+++ b/testdata/make-all.go
@@ -1,16 +1,16 @@
 package testdata
 
 import (
-	"encoding/json"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 )
 
+// DataFmt is an enum type
 type DataFmt int
 
 const (
+	// FolioJSON is the default data format output, the FOLIO JSON format used today
 	FolioJSON DataFmt = iota
+	// JSONArray is the same as FolioJSON but without the key that wraps the array
 	JSONArray
 )
 
@@ -19,35 +19,20 @@ type OutputParams struct {
 	DataFormat DataFmt
 	Indent     bool
 }
+
+// AllParams includes the input parameters FileDefs, and the OutputParams
 type AllParams struct {
-	FileDefs     []FileDef
-	Output       OutputParams
-	NumGroups    int
-	NumUsers     int
-	NumLocations int
-	NumItems     int
-	NumLoans     int
+	FileDefs []FileDef
+	Output   OutputParams
 }
 
-// ParseFileDefs reads the fileDefs.json file and returns a slice of fileDefs
-func ParseFileDefs(filepath string) (fileDefs []FileDef) {
-	if filepath != "" {
-		jsonFile, errOpenFile := os.Open(filepath)
-		if errOpenFile != nil {
-			panic(errOpenFile)
-		}
-		byteValue, _ := ioutil.ReadAll(jsonFile)
-		json.Unmarshal(byteValue, &fileDefs)
+// GenFunc is a function that generates a data output
+type GenFunc func(AllParams, int)
+
+func MakeAll(funcs []GenFunc, p AllParams) {
+	for i, fileDef := range p.FileDefs {
+		funcs[i](p, fileDef.N)
 	}
-	return
-}
-
-func MakeAll(p AllParams) {
-	GenerateGroups(p, p.NumGroups)
-	GenerateUsers(p, p.NumUsers)
-	GenerateLocations(p, p.NumLocations)
-	GenerateStorageItems(p, p.NumItems)
-	GenerateLoans(p, p.NumLoans)
 }
 
 func writeOutput(params OutputParams, filename, jsonKeyname string, slice []interface{}) {

--- a/testdata/make-all.go
+++ b/testdata/make-all.go
@@ -1,6 +1,11 @@
 package testdata
 
-import "path/filepath"
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
 
 type DataFmt int
 
@@ -15,6 +20,7 @@ type OutputParams struct {
 	Indent     bool
 }
 type AllParams struct {
+	FileDefs     []FileDef
 	Output       OutputParams
 	NumGroups    int
 	NumUsers     int
@@ -23,12 +29,25 @@ type AllParams struct {
 	NumLoans     int
 }
 
+// ParseFileDefs reads the fileDefs.json file and returns a slice of fileDefs
+func ParseFileDefs(filepath string) (fileDefs []FileDef) {
+	if filepath != "" {
+		jsonFile, errOpenFile := os.Open(filepath)
+		if errOpenFile != nil {
+			panic(errOpenFile)
+		}
+		byteValue, _ := ioutil.ReadAll(jsonFile)
+		json.Unmarshal(byteValue, &fileDefs)
+	}
+	return
+}
+
 func MakeAll(p AllParams) {
-	GenerateGroups(p.Output, p.NumGroups)
-	GenerateUsers(p.Output, p.NumUsers)
-	GenerateLocations(p.Output, p.NumLocations)
-	GenerateStorageItems(p.Output, p.NumItems)
-	GenerateLoans(p.Output, p.NumLoans)
+	GenerateGroups(p, p.NumGroups)
+	GenerateUsers(p, p.NumUsers)
+	GenerateLocations(p, p.NumLocations)
+	GenerateStorageItems(p, p.NumItems)
+	GenerateLoans(p, p.NumLoans)
 }
 
 func writeOutput(params OutputParams, filename, jsonKeyname string, slice []interface{}) {

--- a/testdata/make-groups.go
+++ b/testdata/make-groups.go
@@ -74,5 +74,6 @@ func GenerateGroups(allParams AllParams, numGroups int) {
 		ObjectKey: objKey,
 		NumFiles:  1,
 		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html",
+		N:         len(groups),
 	}, allParams.Output)
 }

--- a/testdata/make-groups.go
+++ b/testdata/make-groups.go
@@ -19,7 +19,7 @@ type group struct {
 	Metadata groupMetadata `json:"metadata"`
 }
 
-func GenerateGroups(outputParams OutputParams, numGroups int) {
+func GenerateGroups(allParams AllParams, numGroups int) {
 	groupNames := []string{
 		"Freshman", "Sophomore", "Junior", "Senior", "Graduate", "Alumni", "Faculty",
 		"Staff", "Affiliate_A", "Affiliate_B", "Affiliate_C", "Affiliate_D",
@@ -62,16 +62,17 @@ func GenerateGroups(outputParams OutputParams, numGroups int) {
 		g := newGroup(i)
 		groups = append(groups, g)
 	}
+
 	filename := "groups.json"
 	objKey := "usergroups"
-	writeOutput(outputParams, filename, objKey, groups)
+	writeOutput(allParams.Output, filename, objKey, groups)
 
-	updateManifest(fileDef{
+	updateManifest(FileDef{
 		Module:    "mod-users",
 		Path:      "/groups",
 		Filename:  filename,
 		ObjectKey: objKey,
 		NumFiles:  1,
 		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html",
-	}, outputParams)
+	}, allParams.Output)
 }

--- a/testdata/make-loans.go
+++ b/testdata/make-loans.go
@@ -140,7 +140,8 @@ func (lg loanGenerator) run() (counter int) {
 	return
 }
 
-func GenerateLoans(outputParams OutputParams, totalNumTxns int) {
+func GenerateLoans(allParams AllParams, totalNumTxns int) {
+	outputParams := allParams.Output
 	numDays := 365
 	txnPerFile := 100000
 	txnPerDay := int(math.Ceil(float64(totalNumTxns / numDays)))
@@ -161,7 +162,7 @@ func GenerateLoans(outputParams OutputParams, totalNumTxns int) {
 		txnPerFile,
 	}
 	numFiles := lg.run()
-	updateManifest(fileDef{
+	updateManifest(FileDef{
 		Module:    "mod-circulation-storage",
 		Path:      "/loan-storage/loans",
 		Filename:  filename,

--- a/testdata/make-loans.go
+++ b/testdata/make-loans.go
@@ -113,29 +113,25 @@ func (lg loanGenerator) makeLoans(startDay int) (day int, loans []interface{}) {
 	return lg.EndDay, loans
 }
 
-func (lg loanGenerator) generateLoansSingleFile(startDay, callNum int) int {
+func (lg loanGenerator) generateLoansSingleFile(startDay, callNum int) (int, int) {
 	reachedDay, loans := lg.makeLoans(startDay)
 	callNumStr := strconv.Itoa(callNum)
 	filename := lg.Filename + "." + callNumStr
 	writeOutput(lg.outputParams, filename, lg.ObjectKey, loans)
 	totalWritten := strconv.Itoa(((callNum - 1) * lg.TxnPerFile) + len(loans))
 	logger.Debugf("Wrote %d transactions to %s (%s total)\n", len(loans), filename, totalWritten)
-	return reachedDay
+	return reachedDay, len(loans)
 }
-func (lg loanGenerator) recurse(startDay, callNum int) {
-	reachedDay := lg.generateLoansSingleFile(startDay, callNum)
-	if reachedDay != lg.EndDay {
-		lg.recurse(reachedDay, callNum+1)
-	}
-}
-func (lg loanGenerator) run() (counter int) {
+func (lg loanGenerator) run() (counter, totalLoansMade int) {
 	runCount := 0
 	reachedDay := 0
 	for reachedDay != lg.EndDay {
+		var numLoans int
 		runCount++
-		reachedDay = lg.generateLoansSingleFile(reachedDay, runCount)
+		reachedDay, numLoans = lg.generateLoansSingleFile(reachedDay, runCount)
 		logger.Debugf("Run #%d: reached day %d\n", runCount, reachedDay)
 		counter++
+		totalLoansMade += numLoans
 	}
 	return
 }
@@ -161,7 +157,7 @@ func GenerateLoans(allParams AllParams, totalNumTxns int) {
 		txnPerDay,
 		txnPerFile,
 	}
-	numFiles := lg.run()
+	numFiles, totalLoansMade := lg.run()
 	updateManifest(FileDef{
 		Module:    "mod-circulation-storage",
 		Path:      "/loan-storage/loans",
@@ -169,5 +165,6 @@ func GenerateLoans(allParams AllParams, totalNumTxns int) {
 		ObjectKey: objKey,
 		NumFiles:  numFiles,
 		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-circulation-storage/loan-storage.html",
+		N:         totalLoansMade,
 	}, outputParams)
 }

--- a/testdata/make-locations.go
+++ b/testdata/make-locations.go
@@ -10,7 +10,7 @@ type location struct {
 	ID   string `json:"id"`
 }
 
-func GenerateLocations(outputParams OutputParams, numLocations int) {
+func GenerateLocations(allParams AllParams, numLocations int) {
 	makeLocation := func() location {
 		return location{
 			Name: fake.LastName() + " Library",
@@ -25,14 +25,14 @@ func GenerateLocations(outputParams OutputParams, numLocations int) {
 
 	filename := "locations.json"
 	objKey := "locations"
-	writeOutput(outputParams, filename, objKey, locations)
+	writeOutput(allParams.Output, filename, objKey, locations)
 
-	updateManifest(fileDef{
+	updateManifest(FileDef{
 		Module:    "mod-inventory-storage",
 		Path:      "/locations",
 		Filename:  filename,
 		ObjectKey: objKey,
 		NumFiles:  1,
 		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html",
-	}, outputParams)
+	}, allParams.Output)
 }

--- a/testdata/make-locations.go
+++ b/testdata/make-locations.go
@@ -34,5 +34,6 @@ func GenerateLocations(allParams AllParams, numLocations int) {
 		ObjectKey: objKey,
 		NumFiles:  1,
 		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html",
+		N:         numLocations,
 	}, allParams.Output)
 }

--- a/testdata/make-manifest.go
+++ b/testdata/make-manifest.go
@@ -14,6 +14,7 @@ type FileDef struct {
 	ObjectKey string `json:"objectKey"` // the field that contains the array in the output JSON
 	NumFiles  int    `json:"numFiles"`  // the number of files a part of this output
 	Doc       string `json:"doc"`       // URL to the API documentation
+	N         int    `json:"n"`         // Number of objects
 }
 
 func toInterface(originals []FileDef) []interface{} {

--- a/testdata/make-manifest.go
+++ b/testdata/make-manifest.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-type fileDef struct {
+type FileDef struct {
 	Module    string `json:"module"`    // the module
 	Path      string `json:"path"`      // API route simulated
 	Filename  string `json:"filename"`  // the output filename
@@ -16,7 +16,7 @@ type fileDef struct {
 	Doc       string `json:"doc"`       // URL to the API documentation
 }
 
-func toInterface(originals []fileDef) []interface{} {
+func toInterface(originals []FileDef) []interface{} {
 	newThings := make([]interface{}, len(originals))
 	for i, s := range originals {
 		newThings[i] = s
@@ -24,7 +24,7 @@ func toInterface(originals []fileDef) []interface{} {
 	return newThings
 }
 
-func updateManifest(def fileDef, params OutputParams) {
+func updateManifest(def FileDef, params OutputParams) {
 	filepath := filepath.Join(params.OutputDir, "manifest.json")
 
 	jsonFile, errOpeningFile := os.Open(filepath)
@@ -40,7 +40,7 @@ func updateManifest(def fileDef, params OutputParams) {
 		if err != nil {
 			panic(err)
 		}
-		var defs []fileDef
+		var defs []FileDef
 		json.Unmarshal(byteValue, &defs)
 		foundTarget := false
 		for i := 0; i < len(defs); i++ {

--- a/testdata/make-storage-items.go
+++ b/testdata/make-storage-items.go
@@ -35,7 +35,7 @@ func randomCopyNumbers() []string {
 	return []string{strconv.Itoa(random(1, 5))}
 }
 
-func GenerateStorageItems(outputParams OutputParams, numItems int) {
+func GenerateStorageItems(allParams AllParams, numItems int) {
 	rand.Seed(time.Now().UnixNano())
 	makeStorageItem := func() storageItem {
 		return storageItem{
@@ -54,14 +54,14 @@ func GenerateStorageItems(outputParams OutputParams, numItems int) {
 	}
 	filename := "storageItems.json"
 	objKey := "items"
-	writeOutput(outputParams, filename, objKey, storageItems)
+	writeOutput(allParams.Output, filename, objKey, storageItems)
 
-	updateManifest(fileDef{
+	updateManifest(FileDef{
 		Module:    "mod-inventory-storage",
 		Path:      "/item-storage/items",
 		Filename:  filename,
 		ObjectKey: objKey,
 		NumFiles:  1,
 		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html",
-	}, outputParams)
+	}, allParams.Output)
 }

--- a/testdata/make-storage-items.go
+++ b/testdata/make-storage-items.go
@@ -63,5 +63,6 @@ func GenerateStorageItems(allParams AllParams, numItems int) {
 		ObjectKey: objKey,
 		NumFiles:  1,
 		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html",
+		N:         numItems,
 	}, allParams.Output)
 }

--- a/testdata/make-users.go
+++ b/testdata/make-users.go
@@ -27,8 +27,8 @@ func isActive() bool {
 	return false
 }
 
-func GenerateUsers(outputParams OutputParams, numUsers int) {
-	chnl := streamRandomItem(outputParams, "groups.json", "usergroups")
+func GenerateUsers(allParams AllParams, numUsers int) {
+	chnl := streamRandomItem(allParams.Output, "groups.json", "usergroups")
 	makeUser := func() user {
 		randomGroup, _ := <-chnl
 		randomGroupMap := randomGroup.(map[string]interface{})
@@ -51,14 +51,14 @@ func GenerateUsers(outputParams OutputParams, numUsers int) {
 	}
 	filename := "users.json"
 	objKey := "users"
-	writeOutput(outputParams, filename, objKey, users)
+	writeOutput(allParams.Output, filename, objKey, users)
 
-	updateManifest(fileDef{
+	updateManifest(FileDef{
 		Module:    "mod-users",
 		Path:      "/users",
 		Filename:  filename,
 		ObjectKey: objKey,
 		NumFiles:  1,
 		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-users/users.html",
-	}, outputParams)
+	}, allParams.Output)
 }

--- a/testdata/make-users.go
+++ b/testdata/make-users.go
@@ -60,5 +60,6 @@ func GenerateUsers(allParams AllParams, numUsers int) {
 		ObjectKey: objKey,
 		NumFiles:  1,
 		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-users/users.html",
+		N:         numUsers,
 	}, allParams.Output)
 }

--- a/testdata/util.go
+++ b/testdata/util.go
@@ -1,0 +1,104 @@
+package testdata
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// PrintUsage displays the usage ¯\_(ツ)_/¯
+func PrintUsage() {
+	fmt.Println("\ngo run ./cmd/ldp-testdata/main.go [FLAGS]")
+	fmt.Printf("\nAll flags are optional\n\n")
+	flag.PrintDefaults() // Print the flag help strings
+}
+
+// MakeTimestampedDir makes a timestamped directory if the -dir flag is unset
+func MakeTimestampedDir(dirFlag string) string {
+	if dirFlag != "" {
+		os.MkdirAll(dirFlag, os.ModePerm) // Make the directory if it does not already exist
+		return dirFlag
+	}
+	extractDir := "./extract-output"
+	currentTime := time.Now()
+	timeStr := currentTime.Format("20060102_150405")
+	outputDir := filepath.Join(extractDir, timeStr)
+	os.MkdirAll(outputDir, os.ModePerm)
+	return outputDir
+}
+
+// MapFileDefsToFunc checks that each 'path' is valid
+func MapFileDefsToFunc(fileDefs []FileDef) (genFuncs []GenFunc) {
+	validPaths := []string{
+		"/groups",
+		"/users",
+		"/locations",
+		"/item-storage/items",
+		"/loan-storage/loans"}
+
+	for _, def := range fileDefs {
+		switch def.Path {
+		case "/groups":
+			genFuncs = append(genFuncs, GenerateGroups)
+		case "/users":
+			genFuncs = append(genFuncs, GenerateUsers)
+		case "/locations":
+			genFuncs = append(genFuncs, GenerateLocations)
+		case "/item-storage/items":
+			genFuncs = append(genFuncs, GenerateStorageItems)
+		case "/loan-storage/loans":
+			genFuncs = append(genFuncs, GenerateLoans)
+		default:
+			logger.Errorf("Error: '%s' is not a valid path value. \n  Valid paths: \n    %v\n\n", def.Path, strings.Join(validPaths, "\n    "))
+			os.Exit(1)
+		}
+	}
+	return
+}
+
+// ParseFileDefs reads filedefs on the command-line and/or the fileDefs.json file and returns a slice of fileDefs
+func ParseFileDefs(filepath, fileDefsOverrideFlag string, onlyUseOverride bool) (fileDefs []FileDef) {
+	var commandlineFileDefs []FileDef
+	// 1) Parse the command-line filedefs, if any
+	if fileDefsOverrideFlag != "" {
+		marshalErr := json.Unmarshal([]byte(fileDefsOverrideFlag), &commandlineFileDefs)
+		if marshalErr != nil {
+			panic(marshalErr)
+		}
+	}
+	// 2) Check if we're only using the command-line filedefs
+	if onlyUseOverride {
+		return commandlineFileDefs
+	}
+
+	// 3) Parse filedefs.json
+	if filepath != "" {
+		jsonFile, errOpenFile := os.Open(filepath)
+		if errOpenFile != nil {
+			fmt.Println("Error: Cannot find filedefs.json\nPlease run the command from the project root")
+			os.Exit(1)
+		}
+		byteValue, _ := ioutil.ReadAll(jsonFile)
+		json.Unmarshal(byteValue, &fileDefs)
+	}
+
+	// 4) Merge the command-line values over the parsed values
+	if fileDefsOverrideFlag != "" {
+		// Merge in overrides
+		for _, overrideDef := range commandlineFileDefs {
+			for i := range fileDefs {
+				if fileDefs[i].Path == overrideDef.Path {
+					logger.Debugf("Using n=%d for %s\n", overrideDef.N, overrideDef.Path)
+					fileDefs[i].N = overrideDef.N
+					break
+				}
+			}
+		}
+	}
+	return
+}

--- a/web/docs.go
+++ b/web/docs.go
@@ -1,0 +1,1 @@
+package web

--- a/web/index.html
+++ b/web/index.html
@@ -14,33 +14,87 @@
         height: 100px;
       }
       .filedefBox {
-        height: 50px;
         min-width: 100px;
         float: left;
         background-color: #fff;
-        padding: 5px;
+        border: 1px solid #ccc;
+        padding: 15px 5px;
         margin: 5px;
+      }
+      .selected {
+        background-color: #e0f5ff;
+        border: 1px solid #88c3ff;
+      }
+      #mockheader {
+        display: flex;
+        height: 50px;
+        align-content: center;
+        justify-content: flex-start;
+      }
+      #mockheader h3 { 
+        line-height: 50px;
+        margin: 0;
+      }
+      #mockfile {
+        line-height: 50px;
+        margin: 0;
+        padding-left: 10px;
+        font-size: 0.9em;
+        color: #777;
+        background-color: #eee;
+        border-bottom: 1px solid #ccc;
+      }
+      #mockdata {
+        margin: 0;
+        padding: 10px;
+        white-space: pre-wrap;
+        font-size: 0.9em;
+        background-color: #eee;
       }
     </style>
     <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/base-min.css">
+    <script>
+      var lastSelected
+
+      function testdataFetch(elmt, filename, objectKey) {
+        if(lastSelected) lastSelected.classList.remove('selected')
+        elmt.className += ' selected'
+        lastSelected = elmt
+        document.getElementById('mockfile').textContent = '...'
+        document.getElementById('mockdata').textContent = ''
+
+        fetch('/fake/'+filename)
+          .then(response => response.json())
+          .then(resp => {
+            var data = JSON.parse(resp.data)
+            var twenty = data[objectKey].slice(0,20)
+            document.getElementById('mockfile').textContent = resp.file
+            document.getElementById('mockdata').textContent = JSON.stringify(twenty, null, 2)
+          })
+      }
+    </script>
   </head>
-  <body>
+  <body onload="document.querySelector('.filedefBox').click()">
     
     <div class="wrapper">
       <div class="content">
         <h1>ldp-testdata</h1>
         <p>This tool generates fake FOLIO data to support data analysis of future real FOLIO environments.</p>
         
-        <h3>Input</h3>
+        <h3>API</h3>
         <div class="filedefsBox">
           {{#defs}}
-            <div class="filedefBox">
-              <span>{{path}}</span>
+            <div class="filedefBox" onclick="testdataFetch(this, '{{filename}}', '{{objectKey}}')">
+              {{path}}
             </div>
           {{/defs}}
         </div>
 
-        <h3>Output</h3>
+        <div id='mockheader'>
+          <h3>Simulated Data</h3>
+        </div>
+        <pre id='mockfile'></pre>
+        <pre id='mockdata'></pre>
       </div>
     </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>ldp-testdata</title>
+    <style>
+      body {
+        background-color: #ddd;
+      }
+      .wrapper {
+        width: 900px;
+        margin: 0 auto;
+      }
+      .filedefsBox {
+        height: 100px;
+      }
+      .filedefBox {
+        height: 50px;
+        min-width: 100px;
+        float: left;
+        background-color: #fff;
+        padding: 5px;
+        margin: 5px;
+      }
+    </style>
+    <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/base-min.css">
+  </head>
+  <body>
+    
+    <div class="wrapper">
+      <div class="content">
+        <h1>ldp-testdata</h1>
+        <p>This tool generates fake FOLIO data to support data analysis of future real FOLIO environments.</p>
+        
+        <h3>Input</h3>
+        <div class="filedefsBox">
+          {{#defs}}
+            <div class="filedefBox">
+              <span>{{path}}</span>
+            </div>
+          {{/defs}}
+        </div>
+
+        <h3>Output</h3>
+      </div>
+    </div>
+
+  </body>
+</html>
+ 

--- a/web/index.html
+++ b/web/index.html
@@ -6,34 +6,55 @@
       body {
         background-color: #ddd;
       }
+      .clearfix::after {
+        content: "";
+        clear: both;
+        display: table;
+      }
       .wrapper {
         width: 900px;
         margin: 0 auto;
       }
       .filedefsBox {
-        height: 100px;
+        background-color: #eee;
+        border: 1px solid #ccc;
+        margin-bottom: 20px;
+        display: flex;
+        flex-direction: column;
+        height: 400px;
+        width: 400px;
       }
       .filedefBox {
-        min-width: 100px;
-        float: left;
-        background-color: #fff;
-        border: 1px solid #ccc;
-        padding: 15px 5px;
-        margin: 5px;
+        background-color: #eee;
+        border-bottom: 1px solid #ccc;
+        padding: 10px;
+      }
+      .filedefBox label {
+        margin-left: 10px;
+      }
+      .filedefBox label input {
+        width: 80px;
+      }
+      #run-ctrl {
+        display: flex;
+        justify-content: flex-start;
+      }
+      #run-ctrl button {
+        margin-right: 20px;
+      }
+      #run-ctrl span {
+        color: #666;
+        line-height: 34px;
       }
       .selected {
         background-color: #e0f5ff;
         border: 1px solid #88c3ff;
       }
-      #mockheader {
-        display: flex;
-        height: 50px;
-        align-content: center;
-        justify-content: flex-start;
-      }
-      #mockheader h3 { 
-        line-height: 50px;
-        margin: 0;
+      button {
+        background-color: #2196F3;
+        color: #fff;
+        text-transform: uppercase;
+        font-weight: bold;
       }
       #mockfile {
         line-height: 50px;
@@ -52,7 +73,8 @@
         background-color: #eee;
       }
     </style>
-    <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/base-min.css">
+    <!-- <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/base-min.css"> -->
+    <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/pure-nr-min.css">
     <script>
       var lastSelected
 
@@ -74,7 +96,8 @@
       }
     </script>
   </head>
-  <body onload="document.querySelector('.filedefBox').click()">
+  <!-- <body onload="document.querySelector('.filedefBox').click()"> -->
+  <body>
     
     <div class="wrapper">
       <div class="content">
@@ -82,19 +105,26 @@
         <p>This tool generates fake FOLIO data to support data analysis of future real FOLIO environments.</p>
         
         <h3>API</h3>
-        <div class="filedefsBox">
+        <div class="filedefsBox clearfix">
           {{#defs}}
-            <div class="filedefBox" onclick="testdataFetch(this, '{{filename}}', '{{objectKey}}')">
+            <!-- onclick="testdataFetch(this, '{{filename}}', '{{objectKey}}')" -->
+            <div class="filedefBox" >
               {{path}}
+                <label for="option-one" class="pure-checkbox">
+                  n:
+                  <input id="option-one" type="textbox" value="{{n}}">
+                </label>
             </div>
           {{/defs}}
         </div>
-
-        <div id='mockheader'>
-          <h3>Simulated Data</h3>
+        <div id='run-ctrl'>
+          <button class="pure-button pure-button-primary" disabled>Run</button>
+          <span>✔ Up-to-date</span>
         </div>
+
+        <!-- <h3>Simulated Data</h3>
         <pre id='mockfile'></pre>
-        <pre id='mockdata'></pre>
+        <pre id='mockdata'></pre> -->
       </div>
     </div>
 

--- a/web/server.go
+++ b/web/server.go
@@ -1,0 +1,41 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cbroglie/mustache"
+	"github.com/folio-org/ldp-testdata/testdata"
+)
+
+type Obj map[string]interface{}
+type Array []map[string]interface{}
+
+var fileDefs Array
+
+func viewHandler(w http.ResponseWriter, r *http.Request) {
+	wrapper :=
+		Obj{
+			"defs": fileDefs,
+		}
+	str, _ := mustache.RenderFile("web/index.html", wrapper)
+	fmt.Fprintf(w, str)
+}
+
+// Run the web server
+func Run(openInBrowser bool, fDefs []testdata.FileDef) {
+	jsonObj, marshalErr := json.Marshal(fDefs)
+	if marshalErr != nil {
+		panic(marshalErr)
+	}
+	if err := json.Unmarshal(jsonObj, &fileDefs); err != nil {
+		panic(err)
+	}
+
+	http.HandleFunc("/", viewHandler)
+	if openInBrowser {
+		go open("http://localhost:8080/")
+	}
+	panic(http.ListenAndServe(":8080", nil))
+}

--- a/web/server.go
+++ b/web/server.go
@@ -3,24 +3,47 @@ package web
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/cbroglie/mustache"
 	"github.com/folio-org/ldp-testdata/testdata"
 )
 
+// Obj is a JSON object; it can hold a string
 type Obj map[string]interface{}
+
+// Array is a slice of JSON objects
 type Array []map[string]interface{}
 
-var fileDefs Array
+var fileDefs Array // cache the filedefs on server startup
 
 func viewHandler(w http.ResponseWriter, r *http.Request) {
 	wrapper :=
 		Obj{
-			"defs": fileDefs,
+			"defs": fileDefs, // mustache requires a field ('defs') to access the list
 		}
 	str, _ := mustache.RenderFile("web/index.html", wrapper)
 	fmt.Fprintf(w, str)
+}
+func fakeHandler(w http.ResponseWriter, r *http.Request) {
+	filename := r.URL.Path[len("/fake/"):]
+	filepath := "extract-output/default/" + filename
+	b, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		fmt.Println(err)
+	}
+	wrapper :=
+		Obj{
+			"data": string(b),
+			"file": filename,
+		}
+	jsonObj, marshalErr := json.Marshal(wrapper)
+	if marshalErr != nil {
+		panic(marshalErr)
+	}
+	w.Header().Add("Content-Type", "application/json")
+	fmt.Fprintf(w, string(jsonObj))
 }
 
 // Run the web server
@@ -34,6 +57,7 @@ func Run(openInBrowser bool, fDefs []testdata.FileDef) {
 	}
 
 	http.HandleFunc("/", viewHandler)
+	http.HandleFunc("/fake/", fakeHandler)
 	if openInBrowser {
 		go open("http://localhost:8080/")
 	}

--- a/web/util.go
+++ b/web/util.go
@@ -1,0 +1,23 @@
+package web
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+func open(url string) error {
+	var cmd string
+	var args []string
+
+	switch runtime.GOOS {
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start"}
+	case "darwin":
+		cmd = "open"
+	default: // "linux", "freebsd", "openbsd", "netbsd"
+		cmd = "xdg-open"
+	}
+	args = append(args, url)
+	return exec.Command(cmd, args...).Start()
+}


### PR DESCRIPTION
This PR refactors the project's config into JSON, called `filedefs.json`*. This effort continues on the work of https://github.com/folio-org/ldp-testdata/pull/10, where the manifest.json file was made to summarize the output of the program. The only difference between the two files right now is the `n` field, which is the number of objects to simulate.

**Breaking changes**
- The CLI expects to be run from the project root, where filedefs.json is
- Edit `filedefs.json` to change `n` for each `path`
- Or override `filedefs.json` via the command-line:
```shell
go run ./cmd/ldp-testdata/main.go -json='[{"path": "/loan-storage/loans", "n":50000}]'
```

**`config.json` may be a better name. It's named filedefs.json because it contains a slice of FileDef objects, which each define an output file*

This PR also includes a web server which is not used yet. It can display filedefs.json in a user-friendly way.