### PR TITLE
LDP-32: update readme w/ supported APIs, cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To download:
 go get github.com/folio-org/ldp-testdata
 ```
 
-To run:
+To run CLI:
 ```shell
 go run ./cmd/ldp-testdata/main.go
 ```
@@ -56,4 +56,11 @@ use the `-json` flag to override the number of objects set filedefs.json
 go run ./cmd/ldp-testdata/main.go -json='[{"path": "/loan-storage/loans", "n":50000}]'
 ```
 
-**This software is under active development. Use this software only for testing purposes.**
+Supported Routes
+--------
+
+- [/groups](https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html)
+- [/users](https://s3.amazonaws.com/foliodocs/api/mod-users/users.html)
+- [/locations](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html)
+- [/item-storage/items](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html)
+- [/loan-storage/loans](https://s3.amazonaws.com/foliodocs/api/mod-circulation-storage/loan-storage.html)

--- a/cmd/doc/main.go
+++ b/cmd/doc/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/folio-org/ldp-testdata/logging"
+	"github.com/folio-org/ldp-testdata/testdata"
+)
+
+var logger = logging.Logger
+
+func printUsage() {
+	fmt.Println("\ngo run ./cmd/doc/main.go [FLAGS]")
+	fmt.Printf("\nAll flags are optional\n\n")
+	flag.PrintDefaults() // Print the flag help strings
+}
+
+// This script auto-updates the README's Supported Routes section
+// based on filedefs.json
+func main() {
+	logging.Init()
+
+	flag.Usage = func() {
+		printUsage()
+	}
+
+	fileDefsFlag := flag.String("fileDefs", "filedefs.json", "The filepath of the JSON file definitions")
+	flag.Parse()
+	fileDefs := testdata.ParseFileDefs(*fileDefsFlag, "", false)
+
+	file, err := os.Open("README.md")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	atSupportedRoutes := false
+	for scanner.Scan() {
+		text := scanner.Text()
+		if text == "Supported Routes" {
+			atSupportedRoutes = true
+		} else if atSupportedRoutes && strings.HasPrefix(text, "- ") {
+			for strings.HasPrefix(scanner.Text(), "- ") {
+				scanner.Scan()
+			}
+			for _, fileDef := range fileDefs {
+				newText := fmt.Sprintf("- [%s](%s)", fileDef.Path, fileDef.Doc)
+				lines = append(lines, newText)
+			}
+			atSupportedRoutes = false
+			continue
+		}
+		lines = append(lines, text)
+	}
+	writeSliceToFileLineByLine("README.md", lines)
+}
+
+// Writes a file line by line
+func writeSliceToFileLineByLine(filepath string, slice []string) {
+	f, _ := os.Create(filepath)
+	defer f.Close()
+	w := bufio.NewWriter(f)
+	for i := 0; i < len(slice); i++ {
+		w.WriteString(slice[i] + "\n")
+	}
+	w.Flush()
+}

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/folio-org/ldp-testdata/logging"
+	"github.com/folio-org/ldp-testdata/testdata"
+	"github.com/folio-org/ldp-testdata/web"
+)
+
+var logger = logging.Logger
+
+func printUsage() {
+	fmt.Println("\ngo run ./cmd/web/main.go [FLAGS]")
+	fmt.Printf("\nAll flags are optional\n\n")
+	flag.PrintDefaults() // Print the flag help strings
+}
+
+func main() {
+	logging.Init()
+
+	flag.Usage = func() {
+		printUsage()
+	}
+
+	openBrowser := flag.Bool("openBrowser", true, "Whether to open a web browser to the UI")
+	fileDefsFlag := flag.String("fileDefs", "filedefs.json", "The filepath of the JSON file definitions")
+	flag.Parse()
+
+	fileDefs := testdata.ParseFileDefs(*fileDefsFlag, "", false)
+	web.Run(*openBrowser, fileDefs)
+}


### PR DESCRIPTION
- update readme with section **Supported Routes**
- new `doc` cmd: running will update README.md based on filedefs.json
- new `web` cmd: running will run the web server (not yet functional)