### PR TITLE
LDP-52: use patronGroup ID not name for /users

### DIFF
--- a/testdata/make-users.go
+++ b/testdata/make-users.go
@@ -32,14 +32,14 @@ func GenerateUsers(allParams AllParams, numUsers int) {
 	makeUser := func() user {
 		randomGroup, _ := <-chnl
 		randomGroupMap := randomGroup.(map[string]interface{})
-		randomGroupName := randomGroupMap["group"].(string)
+		randomGroupId := randomGroupMap["id"].(string)
 		return user{
 			Username:    fake.UserName(),
 			ID:          uuid.Must(uuid.NewV4()).String(),
 			Barcode:     fake.DigitsN(16),
 			Active:      isActive(),
 			Type:        "patron",
-			PatronGroup: randomGroupName,
+			PatronGroup: randomGroupId,
 			ProxyFor:    make([]string, 0),
 		}
 	}


### PR DESCRIPTION
https://issues.folio.org/browse/LDP-52

Fixes bug that the patronGroup name was used instead of the ID.