### PR TITLE
LDP-53: use consistent naming

### DIFF
--- a/filedefs.json
+++ b/filedefs.json
@@ -2,7 +2,6 @@
   {
       "module": "mod-users",
       "path": "/groups",
-      "filename": "groups.json",
       "objectKey": "usergroups",
       "doc": "https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html",
       "n": 12
@@ -10,7 +9,6 @@
   {
       "module": "mod-users",
       "path": "/users",
-      "filename": "users.json",
       "objectKey": "users",
       "doc": "https://s3.amazonaws.com/foliodocs/api/mod-users/users.html",
       "n": 30000
@@ -18,7 +16,6 @@
   {
       "module": "mod-inventory-storage",
       "path": "/locations",
-      "filename": "locations.json",
       "objectKey": "locations",
       "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html",
       "n": 20
@@ -26,7 +23,6 @@
   {
     "module": "mod-inventory-storage",
     "path": "/material-types",
-    "filename": "material-types.json",
     "objectKey": "mtypes",
     "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/material-type.html",
     "n": 3
@@ -34,7 +30,6 @@
   {
     "module": "mod-inventory-storage",
     "path": "/holdings-storage/holdings",
-    "filename": "holdings.json",
     "objectKey": "holdingsRecords",
     "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/holdings-storage.html",
     "n": 3
@@ -42,7 +37,6 @@
   {
       "module": "mod-inventory-storage",
       "path": "/item-storage/items",
-      "filename": "storageItems.json",
       "objectKey": "items",
       "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html",
       "n": 10000
@@ -50,14 +44,12 @@
   {
       "module": "mod-inventory",
       "path": "/inventory/items",
-      "filename": "inventoryItems.json",
       "objectKey": "items",
       "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory/inventory.html"
   },
   {
       "module": "mod-circulation-storage",
       "path": "/loan-storage/loans",
-      "filename": "loans.json",
       "objectKey": "loans",
       "doc": "https://s3.amazonaws.com/foliodocs/api/mod-circulation-storage/loan-storage.html",
       "n": 10000
@@ -65,7 +57,6 @@
   {
       "module": "mod-circulation",
       "path": "/circulation/loans",
-      "filename": "circloan.json",
       "objectKey": "loans",
       "doc": "https://s3.amazonaws.com/foliodocs/api/mod-circulation/circulation.html",
       "n": 10000

--- a/testdata/make-all.go
+++ b/testdata/make-all.go
@@ -2,6 +2,8 @@ package testdata
 
 import (
 	"path/filepath"
+	"strconv"
+	"strings"
 )
 
 // DataFmt is an enum type
@@ -27,14 +29,18 @@ type AllParams struct {
 }
 
 // GenFunc is a function that generates a data output
-type GenFunc func(AllParams, int)
+type GenFunc func(FileDef, OutputParams)
 
 func MakeAll(funcs []GenFunc, p AllParams) {
 	for i, fileDef := range p.FileDefs {
-		funcs[i](p, fileDef.N)
+		funcs[i](fileDef, p.Output)
 	}
 }
-
+func fileNumStr(def FileDef, num int) string {
+	parts := strings.Split(def.Path, "/")[1:]
+	filename := strings.Join(parts, "-")
+	return filename + "-" + strconv.Itoa(num) + ".json"
+}
 func writeOutput(params OutputParams, filename, jsonKeyname string, slice []interface{}) {
 	filepath := filepath.Join(params.OutputDir, filename)
 	if params.DataFormat == JSONArray {

--- a/testdata/make-groups.go
+++ b/testdata/make-groups.go
@@ -19,7 +19,8 @@ type group struct {
 	Metadata groupMetadata `json:"metadata"`
 }
 
-func GenerateGroups(allParams AllParams, numGroups int) {
+func GenerateGroups(filedef FileDef, outputParams OutputParams) {
+	numGroups := filedef.N
 	groupNames := []string{
 		"Freshman", "Sophomore", "Junior", "Senior", "Graduate", "Alumni", "Faculty",
 		"Staff", "Affiliate_A", "Affiliate_B", "Affiliate_C", "Affiliate_D",
@@ -63,17 +64,7 @@ func GenerateGroups(allParams AllParams, numGroups int) {
 		groups = append(groups, g)
 	}
 
-	filename := "groups.json"
-	objKey := "usergroups"
-	writeOutput(allParams.Output, filename, objKey, groups)
-
-	updateManifest(FileDef{
-		Module:    "mod-users",
-		Path:      "/groups",
-		Filename:  filename,
-		ObjectKey: objKey,
-		NumFiles:  1,
-		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html",
-		N:         len(groups),
-	}, allParams.Output)
+	writeOutput(outputParams, fileNumStr(filedef, 1), filedef.ObjectKey, groups)
+	filedef.NumFiles = 1
+	updateManifest(filedef, outputParams)
 }

--- a/testdata/make-holdings.go
+++ b/testdata/make-holdings.go
@@ -8,29 +8,19 @@ type holding struct {
 	ID string `json:"id"`
 }
 
-func GenerateHoldings(allParams AllParams, numHoldings int) {
+func GenerateHoldings(filedef FileDef, outputParams OutputParams) {
 	makeHolding := func() materialType {
 		return materialType{
 			ID: uuid.Must(uuid.NewV4()).String(),
 		}
 	}
 	var holdings []interface{}
-	for i := 0; i < numHoldings; i++ {
+	for i := 0; i < filedef.N; i++ {
 		h := makeHolding()
 		holdings = append(holdings, h)
 	}
 
-	filename := "holdings.json"
-	objKey := "holdingsRecords"
-	writeOutput(allParams.Output, filename, objKey, holdings)
-
-	updateManifest(FileDef{
-		Module:    "mod-inventory-storage",
-		Path:      "/holdings-storage/holdings",
-		Filename:  filename,
-		ObjectKey: objKey,
-		NumFiles:  1,
-		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/holdings-storage.html",
-		N:         numHoldings,
-	}, allParams.Output)
+	writeOutput(outputParams, fileNumStr(filedef, 1), filedef.ObjectKey, holdings)
+	filedef.NumFiles = 1
+	updateManifest(filedef, outputParams)
 }

--- a/testdata/make-locations.go
+++ b/testdata/make-locations.go
@@ -19,7 +19,7 @@ type locationsFile struct {
 	Locations []location `json:"locations"`
 }
 
-func GenerateLocations(allParams AllParams, numLocations int) {
+func GenerateLocations(filedef FileDef, outputParams OutputParams) {
 	makeLocation := func() location {
 		return location{
 			Name: fake.LastName() + " Library",
@@ -27,24 +27,14 @@ func GenerateLocations(allParams AllParams, numLocations int) {
 		}
 	}
 	var locations []interface{}
-	for i := 0; i < numLocations; i++ {
+	for i := 0; i < filedef.N; i++ {
 		l := makeLocation()
 		locations = append(locations, l)
 	}
 
-	filename := "locations.json"
-	objKey := "locations"
-	writeOutput(allParams.Output, filename, objKey, locations)
-
-	updateManifest(FileDef{
-		Module:    "mod-inventory-storage",
-		Path:      "/locations",
-		Filename:  filename,
-		ObjectKey: objKey,
-		NumFiles:  1,
-		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html",
-		N:         numLocations,
-	}, allParams.Output)
+	writeOutput(outputParams, fileNumStr(filedef, 1), filedef.ObjectKey, locations)
+	filedef.NumFiles = 1
+	updateManifest(filedef, outputParams)
 }
 
 //

--- a/testdata/make-manifest.go
+++ b/testdata/make-manifest.go
@@ -10,7 +10,6 @@ import (
 type FileDef struct {
 	Module    string `json:"module"`    // the module
 	Path      string `json:"path"`      // API route simulated
-	Filename  string `json:"filename"`  // the output filename
 	ObjectKey string `json:"objectKey"` // the field that contains the array in the output JSON
 	NumFiles  int    `json:"numFiles"`  // the number of files a part of this output
 	Doc       string `json:"doc"`       // URL to the API documentation
@@ -45,8 +44,8 @@ func updateManifest(def FileDef, params OutputParams) {
 		json.Unmarshal(byteValue, &defs)
 		foundTarget := false
 		for i := 0; i < len(defs); i++ {
-			if defs[i].Filename == def.Filename {
-				logger.Debugf("Overwriting entry for %s", def.Filename)
+			if defs[i].Path == def.Path {
+				logger.Debugf("Overwriting entry for %s", def.Path)
 				defs[i] = def
 				foundTarget = true
 				break

--- a/testdata/make-material-types.go
+++ b/testdata/make-material-types.go
@@ -10,7 +10,7 @@ type materialType struct {
 	Source string `json:"source"`
 }
 
-func GenerateMaterialTypes(allParams AllParams, numMaterialTypes int) {
+func GenerateMaterialTypes(filedef FileDef, outputParams OutputParams) {
 	typeList := []string{"dvd", "video recording", "microform", "electronic resource", "text",
 		"sound recording", "unspecified", "book"}
 	makeMaterialType := func(typeName string) materialType {
@@ -26,17 +26,7 @@ func GenerateMaterialTypes(allParams AllParams, numMaterialTypes int) {
 		types = append(types, l)
 	}
 
-	filename := "material-types.json"
-	objKey := "mtypes"
-	writeOutput(allParams.Output, filename, objKey, types)
-
-	updateManifest(FileDef{
-		Module:    "mod-inventory-storage",
-		Path:      "/material-types",
-		Filename:  filename,
-		ObjectKey: objKey,
-		NumFiles:  1,
-		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/material-type.html",
-		N:         numMaterialTypes,
-	}, allParams.Output)
+	writeOutput(outputParams, fileNumStr(filedef, 1), filedef.ObjectKey, types)
+	filedef.NumFiles = 1
+	updateManifest(filedef, outputParams)
 }

--- a/testdata/make-storage-items.go
+++ b/testdata/make-storage-items.go
@@ -40,10 +40,10 @@ func randomCopyNumbers() []string {
 	return []string{strconv.Itoa(random(1, 5))}
 }
 
-func GenerateStorageItems(allParams AllParams, numItems int) {
+func GenerateStorageItems(filedef FileDef, outputParams OutputParams) {
 
-	locChnl := streamRandomItem(allParams.Output, "locations.json", "locations")
-	matChnl := streamRandomItem(allParams.Output, "material-types.json", "mtypes")
+	locChnl := streamRandomItem(outputParams, "locations-1.json", "locations")
+	matChnl := streamRandomItem(outputParams, "material-types-1.json", "mtypes")
 
 	rand.Seed(time.Now().UnixNano())
 	makeStorageItem := func() storageItem {
@@ -66,21 +66,12 @@ func GenerateStorageItems(allParams AllParams, numItems int) {
 		}
 	}
 	var storageItems []interface{}
-	for i := 0; i < numItems; i++ {
+	for i := 0; i < filedef.N; i++ {
 		oneStorageItem := makeStorageItem()
 		storageItems = append(storageItems, oneStorageItem)
 	}
-	filename := "storageItems.json"
-	objKey := "items"
-	writeOutput(allParams.Output, filename, objKey, storageItems)
 
-	updateManifest(FileDef{
-		Module:    "mod-inventory-storage",
-		Path:      "/item-storage/items",
-		Filename:  filename,
-		ObjectKey: objKey,
-		NumFiles:  1,
-		Doc:       "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html",
-		N:         numItems,
-	}, allParams.Output)
+	writeOutput(outputParams, fileNumStr(filedef, 1), filedef.ObjectKey, storageItems)
+	filedef.NumFiles = 1
+	updateManifest(filedef, outputParams)
 }


### PR DESCRIPTION
1) Output filenames are now derived from the `path`. This makes the filenames a little more verbose than the short names I gave them before.
2) Output filenames all now include a number. Previously only the loan files had numbers. The number of files in a set is defined in `numFiles` in `manifest.json`
3) The hardcoded filedef in each generate function is gone. We now use the input filedefs.json to write the manifest.json