### PR TITLE
LDP-43, LDP-54: rename extract-output->output; memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
 cmd/ldp-testdata/ldp-testdata
 extract-output
+output
 

--- a/README.md
+++ b/README.md
@@ -62,5 +62,6 @@ Supported Routes
 - [/groups](https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html)
 - [/users](https://s3.amazonaws.com/foliodocs/api/mod-users/users.html)
 - [/locations](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html)
+- [/material-types](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/material-type.html)
 - [/item-storage/items](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html)
 - [/loan-storage/loans](https://s3.amazonaws.com/foliodocs/api/mod-circulation-storage/loan-storage.html)

--- a/filedefs.json
+++ b/filedefs.json
@@ -24,8 +24,7 @@
     "module": "mod-inventory-storage",
     "path": "/material-types",
     "objectKey": "mtypes",
-    "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/material-type.html",
-    "n": 3
+    "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/material-type.html"
   },
   {
     "module": "mod-inventory-storage",

--- a/testdata/make-circulation-loans.go
+++ b/testdata/make-circulation-loans.go
@@ -59,12 +59,12 @@ func makeItemsMap(filepath string) map[string]inventoryItem {
 
 // GenerateCirculationLoans makes the same number of loans as found in loans.json
 func GenerateCirculationLoans(filedef FileDef, outputParams OutputParams) {
-	var circLoans []interface{}
 	itemsPath := filepath.Join(outputParams.OutputDir, "inventory-items-1.json")
 	itemsMap := makeItemsMap(itemsPath)
 	numFiles := countLoanStorageFiles(outputParams.OutputDir)
 	numThings := 0
 	for i := 1; i <= numFiles; i++ {
+		var circLoans []interface{}
 		loanChnl := streamOutputLinearly(outputParams, "loan-storage-loans-"+strconv.Itoa(i)+".json", "loans")
 		for oneLoan := range loanChnl {
 			var loanObj circulationLoan

--- a/testdata/make-inventory-items.go
+++ b/testdata/make-inventory-items.go
@@ -57,5 +57,6 @@ func GenerateInventoryItems(filedef FileDef, outputParams OutputParams) {
 
 	writeOutput(outputParams, fileNumStr(filedef, 1), filedef.ObjectKey, items)
 	filedef.NumFiles = 1
+	filedef.N = len(items)
 	updateManifest(filedef, outputParams)
 }

--- a/testdata/make-material-types.go
+++ b/testdata/make-material-types.go
@@ -27,6 +27,7 @@ func GenerateMaterialTypes(filedef FileDef, outputParams OutputParams) {
 	}
 
 	writeOutput(outputParams, fileNumStr(filedef, 1), filedef.ObjectKey, types)
+	filedef.N = len(typeList)
 	filedef.NumFiles = 1
 	updateManifest(filedef, outputParams)
 }

--- a/testdata/util.go
+++ b/testdata/util.go
@@ -24,7 +24,7 @@ func MakeTimestampedDir(dirFlag string) string {
 		os.MkdirAll(dirFlag, os.ModePerm) // Make the directory if it does not already exist
 		return dirFlag
 	}
-	extractDir := "./extract-output"
+	extractDir := "./output"
 	currentTime := time.Now()
 	timeStr := currentTime.Format("20060102_150405")
 	outputDir := filepath.Join(extractDir, timeStr)

--- a/web/server.go
+++ b/web/server.go
@@ -28,7 +28,7 @@ func viewHandler(w http.ResponseWriter, r *http.Request) {
 }
 func fakeHandler(w http.ResponseWriter, r *http.Request) {
 	filename := r.URL.Path[len("/fake/"):]
-	filepath := "extract-output/default/" + filename
+	filepath := "output/default/" + filename
 	b, err := ioutil.ReadFile(filepath)
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
1) rename extract-output -> output. I know Nassib had suggested testdata-output, but since we're already in the `testdata` directory, I feel like that's unnecessary context.
2) Add material types to README for supported routes. Not adding all routes just yet because not all routes are _completely_ supported. Material types is very simple, just name and ID, so it's complete.
3) Major bug fix: Move `var circLoans []` inside the `for` loop to fix a memory leak. Should improve speed too since we're no longer appending to a _huge_ slice.