### PR TITLE
 LDP-62: add instance-types, instances, fix holdings, ref to materialTypes

### DIFF
--- a/doc/filedefs.md
+++ b/doc/filedefs.md
@@ -48,10 +48,13 @@ The number of objects to generate
 
 For the following filedefs, `n` is irregular:
 
-| Path                | n behavior                             |
-|---------------------|----------------------------------------|
-| /loan-storage/loans | n is approximate¹                      |
-| /inventory/items    | Ignored. Same n as /item-storage/items |
-| /circulation/loans  | Ignored. Same n as /loan-storage/loans |
+| Path                       | n behavior                                     |
+|----------------------------|------------------------------------------------|
+| /loan-storage/loans        | n is approximate¹                              |
+| /instance-types            | n = 10                                         |
+| /holdings-storage/holdings | Ignored. Same n as /instance-storage/instances |
+| /item-storage/items        | Ignored. Same n as /instance-storage/instances |
+| /inventory/items           | Ignored. Same n as /instance-storage/instances |
+| /circulation/loans         | Ignored. Same n as /loan-storage/loans         |
 
 ¹ The current simulation for loan objects over 1 year involves some randomness, which makes meeting an exact number difficult.

--- a/filedefs.json
+++ b/filedefs.json
@@ -28,17 +28,28 @@
   },
   {
     "module": "mod-inventory-storage",
+    "path": "/instance-types",
+    "objectKey": "instanceTypes",
+    "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/instance-type.html"
+  },
+  {
+    "module": "mod-inventory-storage",
+    "path": "/instance-storage/instances",
+    "objectKey": "instances",
+    "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/instance-storage.html",
+    "n": 10000
+  },
+  {
+    "module": "mod-inventory-storage",
     "path": "/holdings-storage/holdings",
     "objectKey": "holdingsRecords",
-    "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/holdings-storage.html",
-    "n": 3
+    "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/holdings-storage.html"
   },
   {
       "module": "mod-inventory-storage",
       "path": "/item-storage/items",
       "objectKey": "items",
-      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html",
-      "n": 10000
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html"
   },
   {
       "module": "mod-inventory",

--- a/testdata/make-circulation-loans.go
+++ b/testdata/make-circulation-loans.go
@@ -1,10 +1,8 @@
 package testdata
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -28,21 +26,6 @@ type circulationLoan struct {
 	Item     circulationLoanItem `json:"item"`
 }
 
-func countLoanStorageFiles(filepath string) (numMatching int) {
-	files, err := ioutil.ReadDir(filepath)
-	if err != nil {
-		logger.Fatal(err)
-	}
-
-	for _, f := range files {
-		if strings.HasPrefix(f.Name(), "loan-storage-loans-") {
-			numMatching++
-			// fmt.Println(f.Name())
-		}
-	}
-	return numMatching
-}
-
 // Return inventoryItems.json as a map, indexed by item ID
 func makeItemsMap(filepath string) map[string]inventoryItem {
 	itemsMap := make(map[string]inventoryItem)
@@ -61,7 +44,7 @@ func makeItemsMap(filepath string) map[string]inventoryItem {
 func GenerateCirculationLoans(filedef FileDef, outputParams OutputParams) {
 	itemsPath := filepath.Join(outputParams.OutputDir, "inventory-items-1.json")
 	itemsMap := makeItemsMap(itemsPath)
-	numFiles := countLoanStorageFiles(outputParams.OutputDir)
+	numFiles := countFilesWithPrefix(outputParams.OutputDir, "loan-storage-loans-")
 	numThings := 0
 	for i := 1; i <= numFiles; i++ {
 		var circLoans []interface{}

--- a/testdata/make-holdings.go
+++ b/testdata/make-holdings.go
@@ -1,22 +1,31 @@
 package testdata
 
 import (
+	"github.com/mitchellh/mapstructure"
 	uuid "github.com/satori/go.uuid"
 )
 
 type holding struct {
-	ID string `json:"id"`
+	ID                  string `json:"id"`
+	InstanceID          string `json:"instanceId"`
+	PermanentLocationID string `json:"permanentLocationId"`
 }
 
 func GenerateHoldings(filedef FileDef, outputParams OutputParams) {
-	makeHolding := func() materialType {
-		return materialType{
-			ID: uuid.Must(uuid.NewV4()).String(),
+	instanceChnl := streamOutputLinearly(outputParams, "instance-storage-instances-1.json", "instances")
+	// numFiles := countFilesWithPrefix(outputParams.OutputDir, "instance-storage-instances")
+
+	makeHolding := func(oneInstance interface{}) holding {
+		var instanceObj instance
+		mapstructure.Decode(oneInstance, &instanceObj)
+		return holding{
+			ID:         uuid.Must(uuid.NewV4()).String(),
+			InstanceID: instanceObj.ID,
 		}
 	}
 	var holdings []interface{}
-	for i := 0; i < filedef.N; i++ {
-		h := makeHolding()
+	for oneInstance := range instanceChnl {
+		h := makeHolding(oneInstance)
 		holdings = append(holdings, h)
 	}
 

--- a/testdata/make-instance-types.go
+++ b/testdata/make-instance-types.go
@@ -1,0 +1,82 @@
+package testdata
+
+type instanceType struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Code   string `json:"code"`
+	Source string `json:"primary"`
+}
+
+func GenerateInstanceTypes(filedef FileDef, outputParams OutputParams) {
+	typeLiterals := []instanceType{
+		instanceType{
+			ID:     "efe2e89b-0525-4535-aa9b-3ff1a131189e",
+			Name:   "tactile image",
+			Code:   "tci",
+			Source: "rdacontent",
+		},
+		instanceType{
+			ID:     "225faa14-f9bf-4ecd-990d-69433c912434",
+			Name:   "two-dimensional moving image",
+			Code:   "tdi",
+			Source: "rdacontent",
+		},
+		instanceType{
+			ID:     "a2c91e87-6bab-44d6-8adb-1fd02481fc4f",
+			Name:   "other",
+			Code:   "xxx",
+			Source: "rdacontent",
+		},
+		instanceType{
+			ID:     "3e3039b7-fda0-4ac4-885a-022d457cb99c",
+			Name:   "three-dimensional moving image",
+			Code:   "tdm",
+			Source: "rdacontent",
+		},
+		instanceType{
+			ID:     "3be24c14-3551-4180-9292-26a786649c8b",
+			Name:   "performed music",
+			Code:   "prm",
+			Source: "rdacontent",
+		},
+		instanceType{
+			ID:     "e6a278fb-565a-4296-a7c5-8eb63d259522",
+			Name:   "tactile notated movement",
+			Code:   "tcn",
+			Source: "rdacontent",
+		},
+		instanceType{
+			ID:     "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
+			Name:   "text",
+			Code:   "txt",
+			Source: "rdacontent",
+		},
+		instanceType{
+			ID:     "2022aa2e-bdde-4dc4-90bc-115e8894b8b3",
+			Name:   "cartographic three-dimensional form",
+			Code:   "crf",
+			Source: "rdacontent",
+		},
+		instanceType{
+			ID:     "3363cdb1-e644-446c-82a4-dc3a1d4395b9",
+			Name:   "cartographic dataset",
+			Code:   "crd",
+			Source: "rdacontent",
+		},
+		instanceType{
+			ID:     "c208544b-9e28-44fa-a13c-f4093d72f798",
+			Name:   "computer program",
+			Code:   "cop",
+			Source: "rdacontent",
+		},
+	}
+
+	var instanceTypes []interface{}
+	for i := 0; i < len(typeLiterals); i++ {
+		instanceTypes = append(instanceTypes, typeLiterals[i])
+	}
+
+	writeOutput(outputParams, fileNumStr(filedef, 1), filedef.ObjectKey, instanceTypes)
+	filedef.NumFiles = 1
+	updateManifest(filedef, outputParams)
+}

--- a/testdata/make-instances.go
+++ b/testdata/make-instances.go
@@ -1,0 +1,61 @@
+package testdata
+
+import (
+	"path"
+	"runtime"
+
+	"github.com/icrowley/fake"
+	"github.com/mitchellh/mapstructure"
+	uuid "github.com/satori/go.uuid"
+)
+
+// RAML: https://github.com/folio-org/mod-inventory-storage/blob/master/ramls/instance.json
+
+type contributer struct {
+	Name                  string `json:"name"`
+	ContributorNameTypeID string `json:"contributorNameTypeId"`
+	Primary               bool   `json:"primary"`
+}
+type instance struct {
+	ID             string        `json:"id"`
+	Title          string        `json:"title"`
+	Source         string        `json:"source"`
+	Contributors   []contributer `json:"contributors"`
+	InstanceTypeID string        `json:"instanceTypeId"`
+}
+
+func GenerateInstances(filedef FileDef, outputParams OutputParams) {
+
+	typeChnl := streamRandomItem(outputParams, "instance-types-1.json", "instanceTypes")
+	bookChnl := make(chan string, 1)
+	_, nameOfThisFile, _, _ := runtime.Caller(0)
+	pkgDir := path.Dir(nameOfThisFile)
+	go streamRandomLine(pkgDir+"/book_titles.txt", bookChnl)
+
+	makeInstance := func() instance {
+		randomBookTitle, _ := <-bookChnl
+		randomType, _ := <-typeChnl
+		var instanceTypeObj instanceType
+		mapstructure.Decode(randomType, &instanceTypeObj)
+
+		return instance{
+			ID:     uuid.Must(uuid.NewV4()).String(),
+			Title:  randomBookTitle,
+			Source: "MARC",
+			Contributors: []contributer{
+				contributer{
+					Name: fake.FullName(),
+				},
+			},
+			InstanceTypeID: instanceTypeObj.ID,
+		}
+	}
+	var instances []interface{}
+	for i := 0; i < filedef.N; i++ {
+		oneInstance := makeInstance()
+		instances = append(instances, oneInstance)
+	}
+	writeOutput(outputParams, fileNumStr(filedef, 1), filedef.ObjectKey, instances)
+	filedef.NumFiles = 1
+	updateManifest(filedef, outputParams)
+}

--- a/testdata/make-manifest.go
+++ b/testdata/make-manifest.go
@@ -8,12 +8,12 @@ import (
 )
 
 type FileDef struct {
-	Module    string `json:"module"`    // the module
-	Path      string `json:"path"`      // API route simulated
-	ObjectKey string `json:"objectKey"` // the field that contains the array in the output JSON
-	NumFiles  int    `json:"numFiles"`  // the number of files a part of this output
-	Doc       string `json:"doc"`       // URL to the API documentation
-	N         int    `json:"n"`         // Number of objects
+	Module    string `json:"module"`      // the module
+	Path      string `json:"path"`        // API route simulated
+	ObjectKey string `json:"objectKey"`   // the field that contains the array in the output JSON
+	NumFiles  int    `json:"numFiles"`    // the number of files a part of this output
+	Doc       string `json:"doc"`         // URL to the API documentation
+	N         int    `json:"n,omitempty"` // Number of objects
 }
 
 func toInterface(originals []FileDef) []interface{} {

--- a/testdata/util.go
+++ b/testdata/util.go
@@ -38,6 +38,10 @@ func MapFileDefsToFunc(fileDefs []FileDef) (genFuncs []GenFunc) {
 		"/groups",
 		"/users",
 		"/locations",
+		"/material-types",
+		"/instance-types",
+		"/instance-storage/instances",
+		"/holdings-storage/holdings",
 		"/item-storage/items",
 		"/inventory/items",
 		"/loan-storage/loans",
@@ -53,6 +57,10 @@ func MapFileDefsToFunc(fileDefs []FileDef) (genFuncs []GenFunc) {
 			genFuncs = append(genFuncs, GenerateLocations)
 		case "/material-types":
 			genFuncs = append(genFuncs, GenerateMaterialTypes)
+		case "/instance-types":
+			genFuncs = append(genFuncs, GenerateInstanceTypes)
+		case "/instance-storage/instances":
+			genFuncs = append(genFuncs, GenerateInstances)
 		case "/holdings-storage/holdings":
 			genFuncs = append(genFuncs, GenerateHoldings)
 		case "/item-storage/items":
@@ -111,4 +119,18 @@ func ParseFileDefs(filepath, fileDefsOverrideFlag string, onlyUseOverride bool) 
 		}
 	}
 	return
+}
+
+func countFilesWithPrefix(filepath, prefix string) (numMatching int) {
+	files, err := ioutil.ReadDir(filepath)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	for _, f := range files {
+		if strings.HasPrefix(f.Name(), prefix) {
+			numMatching++
+			// fmt.Println(f.Name())
+		}
+	}
+	return numMatching
 }


### PR DESCRIPTION
The inventory hierarchy is instance -> holding -> item. To make `holding` complete, I needed to add `instance`, which needed `instance-type`. 

Only `n` for inventory instances is required; n for instances is used for holdings and items