### PR TITLE
LDP-63: fix missing attributes in test data

### DIFF
--- a/filedefs.json
+++ b/filedefs.json
@@ -21,6 +21,13 @@
       "n": 20
   },
   {
+      "module": "mod-inventory-storage",
+      "path": "/location-units/institutions",
+      "objectKey": "locinsts",
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/locationunit.html",
+      "n": 1
+  },
+  {
     "module": "mod-inventory-storage",
     "path": "/material-types",
     "objectKey": "mtypes",

--- a/testdata/make-holdings.go
+++ b/testdata/make-holdings.go
@@ -5,10 +5,14 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+// https://github.com/folio-org/mod-inventory-storage/blob/master/ramls/holdingsrecord.json
+
 type holding struct {
 	ID                  string `json:"id"`
 	InstanceID          string `json:"instanceId"`
 	PermanentLocationID string `json:"permanentLocationId"`
+	CallNumber          string `json:"callNumber"`
+	ShelvingTitle       string `json:"shelvingTitle"`
 }
 
 func GenerateHoldings(filedef FileDef, outputParams OutputParams) {
@@ -19,8 +23,10 @@ func GenerateHoldings(filedef FileDef, outputParams OutputParams) {
 		var instanceObj instance
 		mapstructure.Decode(oneInstance, &instanceObj)
 		return holding{
-			ID:         uuid.Must(uuid.NewV4()).String(),
-			InstanceID: instanceObj.ID,
+			ID:            uuid.Must(uuid.NewV4()).String(),
+			InstanceID:    instanceObj.ID,
+			CallNumber:    randomCallNumber(),
+			ShelvingTitle: instanceObj.Title,
 		}
 	}
 	var holdings []interface{}

--- a/testdata/make-loans.go
+++ b/testdata/make-loans.go
@@ -11,6 +11,8 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+// https://github.com/folio-org/mod-circulation-storage/blob/master/ramls/loan.json
+
 var logger = logging.Logger
 
 type loanStatus struct {

--- a/testdata/make-location-units.go
+++ b/testdata/make-location-units.go
@@ -1,0 +1,36 @@
+package testdata
+
+import (
+	"github.com/icrowley/fake"
+	uuid "github.com/satori/go.uuid"
+)
+
+// https://github.com/folio-org/mod-inventory-storage/blob/master/ramls/locationunit.raml
+// https://github.com/folio-org/mod-inventory-storage/blob/master/ramls/examples/locinst.json
+
+type locationUnit struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+	Code string `json:"code"`
+}
+
+func GenerateLocationUnitInstitutions(filedef FileDef, outputParams OutputParams) {
+	makeLocationUnit := func() locationUnit {
+		name := fake.LastName() + " Library"
+		code := string(name[0]) + "L"
+		return locationUnit{
+			Name: name,
+			ID:   uuid.Must(uuid.NewV4()).String(),
+			Code: code,
+		}
+	}
+	var locationUnits []interface{}
+	for i := 0; i < filedef.N; i++ {
+		l := makeLocationUnit()
+		locationUnits = append(locationUnits, l)
+	}
+
+	writeOutput(outputParams, fileNumStr(filedef, 1), filedef.ObjectKey, locationUnits)
+	filedef.NumFiles = 1
+	updateManifest(filedef, outputParams)
+}

--- a/testdata/make-locations.go
+++ b/testdata/make-locations.go
@@ -2,9 +2,6 @@ package testdata
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 
 	"github.com/icrowley/fake"
 	uuid "github.com/satori/go.uuid"
@@ -42,15 +39,7 @@ func GenerateLocations(filedef FileDef, outputParams OutputParams) {
 //
 
 func readLocations(params OutputParams, filename string) []location {
-	filepath := filepath.Join(params.OutputDir, filename)
-	jsonFile, errOpeningFile := os.Open(filepath)
-	if errOpeningFile != nil {
-		panic(errOpeningFile)
-	}
-	byteValue, err := ioutil.ReadAll(jsonFile)
-	if err != nil {
-		panic(err)
-	}
+	byteValue := readFile(params, filename)
 	var locationsFileObj locationsFile
 	json.Unmarshal(byteValue, &locationsFileObj)
 	return locationsFileObj.Locations

--- a/testdata/make-storage-items.go
+++ b/testdata/make-storage-items.go
@@ -63,7 +63,7 @@ func GenerateStorageItems(filedef FileDef, outputParams OutputParams) {
 			Status:              itemStatus{Name: "Available"},
 			Enumeration:         randomEnumeration(),
 			CopyNumbers:         randomCopyNumbers(),
-			ItemLevelCallNumber: randomCallNumber(),
+			ItemLevelCallNumber: holdingObj.CallNumber,
 			PermanentLocationID: locationObj.ID,
 			MaterialTypeID:      materialObj.ID,
 		}

--- a/testdata/util.go
+++ b/testdata/util.go
@@ -134,3 +134,16 @@ func countFilesWithPrefix(filepath, prefix string) (numMatching int) {
 	}
 	return numMatching
 }
+
+func readFile(params OutputParams, filename string) []byte {
+	filepath := filepath.Join(params.OutputDir, filename)
+	jsonFile, errOpeningFile := os.Open(filepath)
+	if errOpeningFile != nil {
+		panic(errOpeningFile)
+	}
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		panic(err)
+	}
+	return byteValue
+}

--- a/testdata/util.go
+++ b/testdata/util.go
@@ -38,6 +38,7 @@ func MapFileDefsToFunc(fileDefs []FileDef) (genFuncs []GenFunc) {
 		"/groups",
 		"/users",
 		"/locations",
+		"/location-units/institutions",
 		"/material-types",
 		"/instance-types",
 		"/instance-storage/instances",
@@ -55,6 +56,8 @@ func MapFileDefsToFunc(fileDefs []FileDef) (genFuncs []GenFunc) {
 			genFuncs = append(genFuncs, GenerateUsers)
 		case "/locations":
 			genFuncs = append(genFuncs, GenerateLocations)
+		case "/location-units/institutions":
+			genFuncs = append(genFuncs, GenerateLocationUnitInstitutions)
 		case "/material-types":
 			genFuncs = append(genFuncs, GenerateMaterialTypes)
 		case "/instance-types":


### PR DESCRIPTION
Follow-on work to LDP-62 which added the correct inventory hierarchy, starting with /instances.

Holdings now refers to those instances, and items refers to holdings. 

PR also adds the /location-units/institutions, which isn't currently referenced by any other object.