### PR TITLE
LDP-58: support numDays parameter

### DIFF
--- a/stresstest-filedefs.json
+++ b/stresstest-filedefs.json
@@ -4,21 +4,21 @@
       "path": "/groups",
       "objectKey": "usergroups",
       "doc": "https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html",
-      "n": 12
+      "n": 100
   },
   {
       "module": "mod-users",
       "path": "/users",
       "objectKey": "users",
       "doc": "https://s3.amazonaws.com/foliodocs/api/mod-users/users.html",
-      "n": 30000
+      "n": 100000
   },
   {
       "module": "mod-inventory-storage",
       "path": "/locations",
       "objectKey": "locations",
       "doc": "https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html",
-      "n": 20
+      "n": 100
   },
   {
       "module": "mod-inventory-storage",
@@ -69,14 +69,13 @@
       "path": "/loan-storage/loans",
       "objectKey": "loans",
       "doc": "https://s3.amazonaws.com/foliodocs/api/mod-circulation-storage/loan-storage.html",
-      "n": 10000,
-      "numDays": 365
+      "n": 20000000,
+      "numDays": 1825
   },
   {
       "module": "mod-circulation",
       "path": "/circulation/loans",
       "objectKey": "loans",
-      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-circulation/circulation.html",
-      "n": 10000
+      "doc": "https://s3.amazonaws.com/foliodocs/api/mod-circulation/circulation.html"
   }
 ]

--- a/testdata/make-loans.go
+++ b/testdata/make-loans.go
@@ -91,7 +91,7 @@ func GenerateLoans(filedef FileDef, outputParams OutputParams) {
 
 	N := filedef.N
 	numFilesWritten := 0
-	numDays := 365 // approximate; because N cannot be evenly divided into 365 days, the remainder goes into overflow days
+	numDays := filedef.NumDays // approximate; because N might not be evenly divided into 365 days, the remainder goes into overflow days
 	nInFile := 0
 	nInDay := 0
 	maxNInFile := 100000

--- a/testdata/make-manifest.go
+++ b/testdata/make-manifest.go
@@ -14,6 +14,7 @@ type FileDef struct {
 	NumFiles  int    `json:"numFiles"`    // the number of files a part of this output
 	Doc       string `json:"doc"`         // URL to the API documentation
 	N         int    `json:"n,omitempty"` // Number of objects
+	NumDays   int    `json:"numDays,omitempty"`
 }
 
 func toInterface(originals []FileDef) []interface{} {


### PR DESCRIPTION
- Easiest way to do this was to add a field to fileDefs
- checkin stresstest-filedefs.json for an example where numDays is used to generate 5 years worth of loans