### PR TITLE
LDP-66: Link to doc/algorithms from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ Supported Routes
 - [/groups](https://s3.amazonaws.com/foliodocs/api/mod-users/groups.html)
 - [/users](https://s3.amazonaws.com/foliodocs/api/mod-users/users.html)
 - [/locations](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/location.html)
+- [/location-units/institutions](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/locationunit.html)
+- [/service-points](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/service-point.html)
 - [/material-types](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/material-type.html)
+- [/instance-types](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/instance-type.html)
+- [/instance-storage/instances](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/instance-storage.html)
+- [/holdings-storage/holdings](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/holdings-storage.html)
 - [/item-storage/items](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-storage.html)
+- [/inventory/items](https://s3.amazonaws.com/foliodocs/api/mod-inventory/inventory.html)
 - [/loan-storage/loans](https://s3.amazonaws.com/foliodocs/api/mod-circulation-storage/loan-storage.html)
+- [/circulation/loans](https://s3.amazonaws.com/foliodocs/api/mod-circulation/circulation.html)
+
+Additional Documentation
+--------
+
+- [Algorithms used to generate test data](https://github.com/folio-org/ldp-testdata/blob/master/doc/algorithms.md)
+- [Field descriptions for filedefs.json](https://github.com/folio-org/ldp-testdata/blob/master/doc/filedefs.md)

--- a/cmd/doc/main.go
+++ b/cmd/doc/main.go
@@ -42,16 +42,22 @@ func main() {
 	atSupportedRoutes := false
 	for scanner.Scan() {
 		text := scanner.Text()
+		// 1) Find the header
 		if text == "Supported Routes" {
 			atSupportedRoutes = true
+			// 2) Find the first bullet
 		} else if atSupportedRoutes && strings.HasPrefix(text, "- ") {
+			// 3) Scan past all the bullets
 			for strings.HasPrefix(scanner.Text(), "- ") {
 				scanner.Scan()
 			}
+			// 4) Generate new bullets
 			for _, fileDef := range fileDefs {
 				newText := fmt.Sprintf("- [%s](%s)", fileDef.Path, fileDef.Doc)
 				lines = append(lines, newText)
 			}
+			// 5) End scanning this section
+			lines = append(lines, "")
 			atSupportedRoutes = false
 			continue
 		}

--- a/doc/filedefs.md
+++ b/doc/filedefs.md
@@ -50,7 +50,7 @@ For the following filedefs, `n` is irregular:
 
 | Path                       | n behavior                                     |
 |----------------------------|------------------------------------------------|
-| /loan-storage/loans        | n is approximate¹                              |
+| /service-points            | n = 3                                          |
 | /instance-types            | n = 10                                         |
 | /holdings-storage/holdings | Ignored. Same n as /instance-storage/instances |
 | /item-storage/items        | Ignored. Same n as /instance-storage/instances |
@@ -58,3 +58,7 @@ For the following filedefs, `n` is irregular:
 | /circulation/loans         | Ignored. Same n as /loan-storage/loans         |
 
 ¹ The current simulation for loan objects over 1 year involves some randomness, which makes meeting an exact number difficult.
+
+### numDays
+
+Currently only used for the `/loan-storage/loans` filedef. This data is generated over time, `numDays`. To generate data for loan transactions over the course of 5 years (`5*365 = 1825 days`), use `"numDays": 1825` 


### PR DESCRIPTION
- Ran `go run cmd/doc/main.go` to update the list of Supported Routes in the readme based on filedefs.json
- Clarified that code with comments
- Linked to the files in the `doc` directory from the README
- Updated filedefs.md:
  - Removed exception for loans generation; `n` is no longer approximate
  - Added exception for /service-points; `n` is hardcoded to 3
  - Documented `numDays` param, currently only used for loans generation